### PR TITLE
Add Mock contract and remove enclave signer

### DIFF
--- a/src/EspressoSGXTEEVerifier.sol
+++ b/src/EspressoSGXTEEVerifier.sol
@@ -1,14 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {V3QuoteVerifier} from
-    "@automata-network/dcap-attestation/contracts/verifiers/V3QuoteVerifier.sol";
+import {V3QuoteVerifier} from "@automata-network/dcap-attestation/contracts/verifiers/V3QuoteVerifier.sol";
 import {BELE} from "@automata-network/dcap-attestation/contracts/utils/BELE.sol";
 import {Header} from "@automata-network/dcap-attestation/contracts/types/CommonStruct.sol";
-import {
-    HEADER_LENGTH,
-    ENCLAVE_REPORT_LENGTH
-} from "@automata-network/dcap-attestation/contracts/types/Constants.sol";
+import {HEADER_LENGTH, ENCLAVE_REPORT_LENGTH} from "@automata-network/dcap-attestation/contracts/types/Constants.sol";
 import {EnclaveReport} from "@automata-network/dcap-attestation/contracts/types/V3Structs.sol";
 import {BytesUtils} from "@automata-network/dcap-attestation/contracts/utils/BytesUtils.sol";
 import "@openzeppelin/contracts/access/Ownable2Step.sol";
@@ -29,7 +25,10 @@ contract EspressoSGXTEEVerifier is IEspressoSGXTEEVerifier, Ownable2Step {
     mapping(bytes32 => bool) public registeredEnclaveHash;
     mapping(address => bool) public registeredSigners;
 
-    constructor(bytes32 enclaveHash, address _quoteVerifier) Ownable(msg.sender) {
+    constructor(
+        bytes32 enclaveHash,
+        address _quoteVerifier
+    ) Ownable(msg.sender) {
         if (_quoteVerifier == address(0) || _quoteVerifier.code.length <= 0) {
             revert InvalidQuoteVerifierAddress();
         }
@@ -43,11 +42,10 @@ contract EspressoSGXTEEVerifier is IEspressoSGXTEEVerifier, Ownable2Step {
         @param rawQuote The quote from the TEE
         @param reportDataHash The hash of the report data
     */
-    function verify(bytes calldata rawQuote, bytes32 reportDataHash)
-        public
-        view
-        returns (EnclaveReport memory)
-    {
+    function verify(
+        bytes calldata rawQuote,
+        bytes32 reportDataHash
+    ) public view returns (EnclaveReport memory) {
         // Parse the header
         Header memory header = parseQuoteHeader(rawQuote);
 
@@ -57,7 +55,7 @@ contract EspressoSGXTEEVerifier is IEspressoSGXTEEVerifier, Ownable2Step {
         }
 
         // Verify the quote
-        (bool success,) = quoteVerifier.verifyQuote(header, rawQuote);
+        (bool success, ) = quoteVerifier.verifyQuote(header, rawQuote);
         if (!success) {
             revert InvalidQuote();
         }
@@ -65,7 +63,9 @@ contract EspressoSGXTEEVerifier is IEspressoSGXTEEVerifier, Ownable2Step {
         // Parse enclave quote
         uint256 lastIndex = HEADER_LENGTH + ENCLAVE_REPORT_LENGTH;
         EnclaveReport memory localReport;
-        (success, localReport) = parseEnclaveReport(rawQuote[HEADER_LENGTH:lastIndex]);
+        (success, localReport) = parseEnclaveReport(
+            rawQuote[HEADER_LENGTH:lastIndex]
+        );
         if (!success) {
             revert FailedToParseEnclaveReport();
         }
@@ -77,7 +77,9 @@ contract EspressoSGXTEEVerifier is IEspressoSGXTEEVerifier, Ownable2Step {
 
         //  Verify that the reportDataHash if the hash signed by the TEE
         // We do not check the signature because `quoteVerifier.verifyQuote` already does that
-        if (reportDataHash != bytes32(localReport.reportData.substring(0, 32))) {
+        if (
+            reportDataHash != bytes32(localReport.reportData.substring(0, 32))
+        ) {
             revert InvalidReportDataHash();
         }
 
@@ -89,7 +91,10 @@ contract EspressoSGXTEEVerifier is IEspressoSGXTEEVerifier, Ownable2Step {
         @param attestation The attestation from the TEE
         @param data which the TEE has attested to
     */
-    function registerSigner(bytes calldata attestation, bytes calldata data) external {
+    function registerSigner(
+        bytes calldata attestation,
+        bytes calldata data
+    ) external {
         // Check that the data length is 20 bytes because an address is 20 bytes
         if (data.length != 20) {
             revert InvalidDataLength();
@@ -97,7 +102,10 @@ contract EspressoSGXTEEVerifier is IEspressoSGXTEEVerifier, Ownable2Step {
 
         bytes32 signerAddressHash = keccak256(data);
 
-        EnclaveReport memory localReport = verify(attestation, signerAddressHash);
+        EnclaveReport memory localReport = verify(
+            attestation,
+            signerAddressHash
+        );
 
         if (localReport.reportData.length < 20) {
             revert ReportDataTooShort();
@@ -112,7 +120,7 @@ contract EspressoSGXTEEVerifier is IEspressoSGXTEEVerifier, Ownable2Step {
         // Mark the signer as registered
         if (!registeredSigners[signer]) {
             registeredSigners[signer] = true;
-            emit SignerResgistered(signer, localReport.mrEnclaver);
+            emit SignerRegistered(signer, localReport.mrEnclave);
         }
     }
 
@@ -121,7 +129,9 @@ contract EspressoSGXTEEVerifier is IEspressoSGXTEEVerifier, Ownable2Step {
         @param rawQuote The raw quote in bytes
         @return header The parsed header
     */
-    function parseQuoteHeader(bytes calldata rawQuote) public pure returns (Header memory header) {
+    function parseQuoteHeader(
+        bytes calldata rawQuote
+    ) public pure returns (Header memory header) {
         header = Header({
             version: uint16(BELE.leBytesToBeUint(rawQuote[0:2])),
             attestationKeyType: bytes2(rawQuote[2:4]),
@@ -139,11 +149,9 @@ contract EspressoSGXTEEVerifier is IEspressoSGXTEEVerifier, Ownable2Step {
         @return success True if the enclave report was parsed successfully
         @return enclaveReport The parsed enclave report
     */
-    function parseEnclaveReport(bytes memory rawEnclaveReport)
-        public
-        pure
-        returns (bool success, EnclaveReport memory enclaveReport)
-    {
+    function parseEnclaveReport(
+        bytes memory rawEnclaveReport
+    ) public pure returns (bool success, EnclaveReport memory enclaveReport) {
         if (rawEnclaveReport.length != ENCLAVE_REPORT_LENGTH) {
             return (false, enclaveReport);
         }
@@ -155,19 +163,28 @@ contract EspressoSGXTEEVerifier is IEspressoSGXTEEVerifier, Ownable2Step {
         enclaveReport.reserved2 = bytes32(rawEnclaveReport.substring(96, 32));
         enclaveReport.mrSigner = bytes32(rawEnclaveReport.substring(128, 32));
         enclaveReport.reserved3 = rawEnclaveReport.substring(160, 96);
-        enclaveReport.isvProdId = uint16(BELE.leBytesToBeUint(rawEnclaveReport.substring(256, 2)));
-        enclaveReport.isvSvn = uint16(BELE.leBytesToBeUint(rawEnclaveReport.substring(258, 2)));
+        enclaveReport.isvProdId = uint16(
+            BELE.leBytesToBeUint(rawEnclaveReport.substring(256, 2))
+        );
+        enclaveReport.isvSvn = uint16(
+            BELE.leBytesToBeUint(rawEnclaveReport.substring(258, 2))
+        );
         enclaveReport.reserved4 = rawEnclaveReport.substring(260, 60);
         enclaveReport.reportData = rawEnclaveReport.substring(320, 64);
         success = true;
     }
 
-    function setEnclaveHash(bytes32 enclaveHash, bool valid) external onlyOwner {
+    function setEnclaveHash(
+        bytes32 enclaveHash,
+        bool valid
+    ) external onlyOwner {
         registeredEnclaveHash[enclaveHash] = valid;
         emit EnclaveHashSet(enclaveHash, valid);
     }
 
-    function deleteRegisteredSigners(address[] memory signers) external onlyOwner {
+    function deleteRegisteredSigners(
+        address[] memory signers
+    ) external onlyOwner {
         for (uint256 i = 0; i < signers.length; i++) {
             delete registeredSigners[signers[i]];
             emit DeletedRegisteredSigner(signers[i]);

--- a/src/EspressoSGXTEEVerifier.sol
+++ b/src/EspressoSGXTEEVerifier.sol
@@ -27,18 +27,14 @@ contract EspressoSGXTEEVerifier is IEspressoSGXTEEVerifier, Ownable2Step {
     V3QuoteVerifier public quoteVerifier;
 
     mapping(bytes32 => bool) public registeredEnclaveHash;
-    mapping(bytes32 => bool) public registeredEnclaveSigner;
     mapping(address => bool) public registeredSigners;
 
-    constructor(bytes32 enclaveHash, bytes32 enclaveSigner, address _quoteVerifier)
-        Ownable(msg.sender)
-    {
+    constructor(bytes32 enclaveHash, address _quoteVerifier) Ownable(msg.sender) {
         if (_quoteVerifier == address(0) || _quoteVerifier.code.length <= 0) {
             revert InvalidQuoteVerifierAddress();
         }
         quoteVerifier = V3QuoteVerifier(_quoteVerifier);
         registeredEnclaveHash[enclaveHash] = true;
-        registeredEnclaveSigner[enclaveSigner] = true;
     }
 
     /*
@@ -77,10 +73,6 @@ contract EspressoSGXTEEVerifier is IEspressoSGXTEEVerifier, Ownable2Step {
         // Check that mrEnclave match
         if (!registeredEnclaveHash[localReport.mrEnclave]) {
             revert InvalidEnclaveHash();
-        }
-
-        if (!registeredEnclaveSigner[localReport.mrSigner]) {
-            revert InvalidEnclaveSigner();
         }
 
         //  Verify that the reportDataHash if the hash signed by the TEE
@@ -173,11 +165,6 @@ contract EspressoSGXTEEVerifier is IEspressoSGXTEEVerifier, Ownable2Step {
     function setEnclaveHash(bytes32 enclaveHash, bool valid) external onlyOwner {
         registeredEnclaveHash[enclaveHash] = valid;
         emit EnclaveHashSet(enclaveHash, valid);
-    }
-
-    function setEnclaveSigner(bytes32 enclaveSigner, bool valid) external onlyOwner {
-        registeredEnclaveSigner[enclaveSigner] = valid;
-        emit EnclaveSignerSet(enclaveSigner, valid);
     }
 
     function deleteRegisteredSigners(address[] memory signers) external onlyOwner {

--- a/src/EspressoSGXTEEVerifier.sol
+++ b/src/EspressoSGXTEEVerifier.sol
@@ -112,7 +112,7 @@ contract EspressoSGXTEEVerifier is IEspressoSGXTEEVerifier, Ownable2Step {
         // Mark the signer as registered
         if (!registeredSigners[signer]) {
             registeredSigners[signer] = true;
-            emit SignerResgistered(signer, localReport.mrEnclave, localReport.mrSigner);
+            emit SignerResgistered(signer, localReport.mrEnclaver);
         }
     }
 

--- a/src/EspressoTEEVerifier.sol
+++ b/src/EspressoTEEVerifier.sol
@@ -75,22 +75,6 @@ contract EspressoTEEVerifier is Ownable2Step, IEspressoTEEVerifier {
         revert UnsupportedTeeType();
     }
 
-    /**
-     * @notice This function retrieves whether an enclave signer is registered or not
-     *     @param enclaveSigner The enclave signer
-     *     @param teeType The type of TEE
-     */
-    function registeredEnclaveSigners(bytes32 enclaveSigner, TeeType teeType)
-        external
-        view
-        returns (bool)
-    {
-        if (teeType == TeeType.SGX) {
-            return espressoSGXTEEVerifier.registeredEnclaveSigner(enclaveSigner);
-        }
-        revert UnsupportedTeeType();
-    }
-
     /*
         @notice Set the EspressoSGXTEEVerifier
         @param _espressoSGXTEEVerifier The address of the EspressoSGXTEEVerifier

--- a/src/interface/IEspressoSGXTEEVerifier.sol
+++ b/src/interface/IEspressoSGXTEEVerifier.sol
@@ -13,8 +13,6 @@ interface IEspressoSGXTEEVerifier {
     error FailedToParseEnclaveReport();
     // This error is thrown when the mrEnclave don't match
     error InvalidEnclaveHash();
-    // This error is thrown when the mrSigner don't match
-    error InvalidEnclaveSigner();
     // This error is thrown when the reportDataHash doesn't match the hash signed by the TEE
     error InvalidReportDataHash();
     // This error is thrown when the reportData is too short
@@ -27,13 +25,11 @@ interface IEspressoSGXTEEVerifier {
     error InvalidQuoteVerifierAddress();
 
     event EnclaveHashSet(bytes32 enclaveHash, bool valid);
-    event EnclaveSignerSet(bytes32 enclaveSigner, bool valid);
-    event SignerResgistered(address signer, bytes32 enclaveHash, bytes32 enclaveSigner);
+    event SignerResgistered(address signer, bytes32 enclaveHash);
     event DeletedRegisteredSigner(address signer);
 
     function registeredSigners(address signer) external view returns (bool);
     function registeredEnclaveHash(bytes32 enclaveHash) external view returns (bool);
-    function registeredEnclaveSigner(bytes32 enclaveSigner) external view returns (bool);
 
     function registerSigner(bytes calldata attestation, bytes calldata data) external;
 
@@ -53,6 +49,5 @@ interface IEspressoSGXTEEVerifier {
         returns (bool success, EnclaveReport memory enclaveReport);
 
     function setEnclaveHash(bytes32 enclaveHash, bool valid) external;
-    function setEnclaveSigner(bytes32 enclaveSigner, bool valid) external;
     function deleteRegisteredSigners(address[] memory signers) external;
 }

--- a/src/interface/IEspressoSGXTEEVerifier.sol
+++ b/src/interface/IEspressoSGXTEEVerifier.sol
@@ -29,27 +29,24 @@ interface IEspressoSGXTEEVerifier {
     event DeletedRegisteredSigner(address signer);
 
     function registeredSigners(address signer) external view returns (bool);
-    function registeredEnclaveHash(
-        bytes32 enclaveHash
-    ) external view returns (bool);
+    function registeredEnclaveHash(bytes32 enclaveHash) external view returns (bool);
 
-    function registerSigner(
-        bytes calldata attestation,
-        bytes calldata data
-    ) external;
+    function registerSigner(bytes calldata attestation, bytes calldata data) external;
 
-    function verify(
-        bytes calldata rawQuote,
-        bytes32 reportDataHash
-    ) external view returns (EnclaveReport memory);
+    function verify(bytes calldata rawQuote, bytes32 reportDataHash)
+        external
+        view
+        returns (EnclaveReport memory);
 
-    function parseQuoteHeader(
-        bytes calldata rawQuote
-    ) external pure returns (Header memory header);
+    function parseQuoteHeader(bytes calldata rawQuote)
+        external
+        pure
+        returns (Header memory header);
 
-    function parseEnclaveReport(
-        bytes memory rawEnclaveReport
-    ) external pure returns (bool success, EnclaveReport memory enclaveReport);
+    function parseEnclaveReport(bytes memory rawEnclaveReport)
+        external
+        pure
+        returns (bool success, EnclaveReport memory enclaveReport);
 
     function setEnclaveHash(bytes32 enclaveHash, bool valid) external;
     function deleteRegisteredSigners(address[] memory signers) external;

--- a/src/interface/IEspressoSGXTEEVerifier.sol
+++ b/src/interface/IEspressoSGXTEEVerifier.sol
@@ -25,28 +25,31 @@ interface IEspressoSGXTEEVerifier {
     error InvalidQuoteVerifierAddress();
 
     event EnclaveHashSet(bytes32 enclaveHash, bool valid);
-    event SignerResgistered(address signer, bytes32 enclaveHash);
+    event SignerRegistered(address signer, bytes32 enclaveHash);
     event DeletedRegisteredSigner(address signer);
 
     function registeredSigners(address signer) external view returns (bool);
-    function registeredEnclaveHash(bytes32 enclaveHash) external view returns (bool);
+    function registeredEnclaveHash(
+        bytes32 enclaveHash
+    ) external view returns (bool);
 
-    function registerSigner(bytes calldata attestation, bytes calldata data) external;
+    function registerSigner(
+        bytes calldata attestation,
+        bytes calldata data
+    ) external;
 
-    function verify(bytes calldata rawQuote, bytes32 reportDataHash)
-        external
-        view
-        returns (EnclaveReport memory);
+    function verify(
+        bytes calldata rawQuote,
+        bytes32 reportDataHash
+    ) external view returns (EnclaveReport memory);
 
-    function parseQuoteHeader(bytes calldata rawQuote)
-        external
-        pure
-        returns (Header memory header);
+    function parseQuoteHeader(
+        bytes calldata rawQuote
+    ) external pure returns (Header memory header);
 
-    function parseEnclaveReport(bytes memory rawEnclaveReport)
-        external
-        pure
-        returns (bool success, EnclaveReport memory enclaveReport);
+    function parseEnclaveReport(
+        bytes memory rawEnclaveReport
+    ) external pure returns (bool success, EnclaveReport memory enclaveReport);
 
     function setEnclaveHash(bytes32 enclaveHash, bool valid) external;
     function deleteRegisteredSigners(address[] memory signers) external;

--- a/src/interface/IEspressoTEEVerifier.sol
+++ b/src/interface/IEspressoTEEVerifier.sol
@@ -33,11 +33,6 @@ interface IEspressoTEEVerifier {
         view
         returns (bool);
 
-    function registeredEnclaveSigners(bytes32 enclaveSigner, TeeType teeType)
-        external
-        view
-        returns (bool);
-
     // Function to set the EspressoSGXTEEVerifier
     function setEspressoSGXTEEVerifier(IEspressoSGXTEEVerifier _espressoSGXTEEVerifier) external;
 }

--- a/src/mocks/EspressoTEEVerifier.sol
+++ b/src/mocks/EspressoTEEVerifier.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ *
+ * @title  Verifies quotes from the TEE and attests on-chain
+ * @notice Contains the logic to verify a quote from the TEE and attest on-chain. It uses the V3QuoteVerifier contract
+ *         to verify the quote. Along with some additional verification logic.
+ */
+contract EspressoTEEVerifierMock {
+    enum TeeType {
+        SGX
+    }
+
+    mapping(address => bool) public registeredSigner;
+
+    constructor() {}
+
+    function verify(bytes calldata signature, bytes32 userDataHash) external {
+        return;
+    }
+
+    function registerSigner(bytes calldata attestation, bytes calldata data, TeeType teeType)
+        external
+    {
+        // data length should be 20 bytes
+        require(data.length == 20, "Invalid data length");
+
+        address signer = address(uint160(bytes20(data[:20])));
+        registeredSigner[signer] = true;
+    }
+
+    function registeredSigners(address signer, TeeType teeType) external view returns (bool) {
+        return registeredSigner[signer];
+    }
+}

--- a/test/EspressoSGXTEEVerifier.t.sol
+++ b/test/EspressoSGXTEEVerifier.t.sol
@@ -16,8 +16,7 @@ contract EspressoSGXTEEVerifierTest is Test {
         bytes32(0x38f8abca50cdede6a00d405856857bc3d81135624ee0e287640956d11cc22d5e);
     bytes32 enclaveHash =
         bytes32(0x01f7290cb6bbaa427eca3daeb25eecccb87c4b61259b1ae2125182c4d77169c0);
-    bytes32 enclaveSigner =
-        bytes32(0x5fc862cb2e7e1f449f36a18b18aca08c20feaed0d411247816c281d596420cbb);
+
     //  Address of the automata V3QuoteVerifier deployed on sepolia
     address v3QuoteVerifier = address(0x6E64769A13617f528a2135692484B681Ee1a7169);
 
@@ -27,8 +26,7 @@ contract EspressoSGXTEEVerifierTest is Test {
         );
         // Get the instance of the DCAP Attestation QuoteVerifier on the Arbitrum Sepolia Rollup
         vm.startPrank(adminTEE);
-        espressoSGXTEEVerifier =
-            new EspressoSGXTEEVerifier(enclaveHash, enclaveSigner, v3QuoteVerifier);
+        espressoSGXTEEVerifier = new EspressoSGXTEEVerifier(enclaveHash, v3QuoteVerifier);
         vm.stopPrank();
     }
 
@@ -194,22 +192,8 @@ contract EspressoSGXTEEVerifierTest is Test {
         bytes memory sampleQuote = vm.readFileBinary(inputFile);
         bytes32 incorrectMrEnclave =
             bytes32(0x51dfe95acffa8a4075b716257c836895af9202a5fd56c8c2208dacb79c659ff1);
-        espressoSGXTEEVerifier =
-            new EspressoSGXTEEVerifier(incorrectMrEnclave, enclaveSigner, v3QuoteVerifier);
+        espressoSGXTEEVerifier = new EspressoSGXTEEVerifier(incorrectMrEnclave, v3QuoteVerifier);
         vm.expectRevert(IEspressoSGXTEEVerifier.InvalidEnclaveHash.selector);
-        espressoSGXTEEVerifier.verify(sampleQuote, reportDataHash);
-    }
-
-    function testIncorrectEnclaveSigner() public {
-        vm.startPrank(adminTEE);
-        string memory quotePath = "/test/configs/attestation.bin";
-        string memory inputFile = string.concat(vm.projectRoot(), quotePath);
-        bytes memory sampleQuote = vm.readFileBinary(inputFile);
-        bytes32 incorrectMrSigner =
-            bytes32(0x51dfe95acffa8a4075b716257c836895af9202a5fd56c8c2208dacb79c659ff1);
-        espressoSGXTEEVerifier =
-            new EspressoSGXTEEVerifier(enclaveHash, incorrectMrSigner, v3QuoteVerifier);
-        vm.expectRevert(IEspressoSGXTEEVerifier.InvalidEnclaveSigner.selector);
         espressoSGXTEEVerifier.verify(sampleQuote, reportDataHash);
     }
 
@@ -227,23 +211,6 @@ contract EspressoSGXTEEVerifierTest is Test {
             abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, fakeAddress)
         );
         espressoSGXTEEVerifier.setEnclaveHash(newMrEnclave, true);
-        vm.stopPrank();
-    }
-
-    function testSetEnclaveSigner() public {
-        vm.startPrank(adminTEE);
-        bytes32 newMrSigner = bytes32(hex"01");
-        espressoSGXTEEVerifier.setEnclaveSigner(newMrSigner, true);
-        assertEq(espressoSGXTEEVerifier.registeredEnclaveSigner(newMrSigner), true);
-        espressoSGXTEEVerifier.setEnclaveSigner(newMrSigner, false);
-        assertEq(espressoSGXTEEVerifier.registeredEnclaveSigner(newMrSigner), false);
-        vm.stopPrank();
-        // Check that only owner can set the signer
-        vm.startPrank(fakeAddress);
-        vm.expectRevert(
-            abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, fakeAddress)
-        );
-        espressoSGXTEEVerifier.setEnclaveSigner(newMrSigner, true);
         vm.stopPrank();
     }
 

--- a/test/EspressoTEEVerifier.t.sol
+++ b/test/EspressoTEEVerifier.t.sol
@@ -16,8 +16,6 @@ contract EspressoTEEVerifierTest is Test {
     EspressoSGXTEEVerifier espressoSGXTEEVerifier;
     bytes32 enclaveHash =
         bytes32(0x01f7290cb6bbaa427eca3daeb25eecccb87c4b61259b1ae2125182c4d77169c0);
-    bytes32 enclaveSigner =
-        bytes32(0x5fc862cb2e7e1f449f36a18b18aca08c20feaed0d411247816c281d596420cbb);
     //  Address of the automata V3QuoteVerifier deployed on sepolia
     address v3QuoteVerifier = address(0x6E64769A13617f528a2135692484B681Ee1a7169);
 
@@ -28,8 +26,7 @@ contract EspressoTEEVerifierTest is Test {
         // Get the instance of the DCAP Attestation QuoteVerifier on the Arbitrum Sepolia Rollup
         vm.startPrank(adminTEE);
 
-        espressoSGXTEEVerifier =
-            new EspressoSGXTEEVerifier(enclaveHash, enclaveSigner, v3QuoteVerifier);
+        espressoSGXTEEVerifier = new EspressoSGXTEEVerifier(enclaveHash, v3QuoteVerifier);
         espressoTEEVerifier = new EspressoTEEVerifier(espressoSGXTEEVerifier);
         vm.stopPrank();
     }
@@ -79,20 +76,10 @@ contract EspressoTEEVerifierTest is Test {
         );
     }
 
-    function testRegisteredEnclaveSigner() public {
-        assertEq(
-            espressoTEEVerifier.registeredEnclaveSigners(
-                bytes32(0x5fc862cb2e7e1f449f36a18b18aca08c20feaed0d411247816c281d596420cbb),
-                IEspressoTEEVerifier.TeeType.SGX
-            ),
-            true
-        );
-    }
-
     function testSetEspressoSGXTEEVerifier() public {
         vm.startPrank(adminTEE);
         IEspressoSGXTEEVerifier newEspressoSGXTEEVerifier =
-            new EspressoSGXTEEVerifier(enclaveHash, enclaveSigner, v3QuoteVerifier);
+            new EspressoSGXTEEVerifier(enclaveHash, v3QuoteVerifier);
         espressoTEEVerifier.setEspressoSGXTEEVerifier(newEspressoSGXTEEVerifier);
         assertEq(
             address(espressoTEEVerifier.espressoSGXTEEVerifier()),


### PR DESCRIPTION
- Removing `Enclave Signer` from the TEE contract because we dont need this for Permissionless/Stateless Batcher
 - Adding Mock contract to espresso-tee-contracts