### PR TITLE
Fix transfer ownership to be compatible with nitro contracts

### DIFF
--- a/src/EspressoSGXTEEVerifier.sol
+++ b/src/EspressoSGXTEEVerifier.sol
@@ -29,12 +29,13 @@ contract EspressoSGXTEEVerifier is IEspressoSGXTEEVerifier, Ownable2Step {
     mapping(bytes32 => bool) public registeredEnclaveHash;
     mapping(address => bool) public registeredSigners;
 
-    constructor(bytes32 enclaveHash, address _quoteVerifier) Ownable(msg.sender) {
+    constructor(bytes32 enclaveHash, address _quoteVerifier) Ownable() {
         if (_quoteVerifier == address(0) || _quoteVerifier.code.length <= 0) {
             revert InvalidQuoteVerifierAddress();
         }
         quoteVerifier = V3QuoteVerifier(_quoteVerifier);
         registeredEnclaveHash[enclaveHash] = true;
+        _transferOwnership(msg.sender);
     }
 
     /*

--- a/src/EspressoTEEVerifier.sol
+++ b/src/EspressoTEEVerifier.sol
@@ -14,8 +14,9 @@ import {IEspressoTEEVerifier} from "./interface/IEspressoTEEVerifier.sol";
 contract EspressoTEEVerifier is Ownable2Step, IEspressoTEEVerifier {
     IEspressoSGXTEEVerifier public espressoSGXTEEVerifier;
 
-    constructor(IEspressoSGXTEEVerifier _espressoSGXTEEVerifier) Ownable(msg.sender) {
+    constructor(IEspressoSGXTEEVerifier _espressoSGXTEEVerifier) Ownable() {
         espressoSGXTEEVerifier = _espressoSGXTEEVerifier;
+        _transferOwnership(msg.sender);
     }
 
     /**


### PR DESCRIPTION
To make the Ownable contract compatible with nitro-contracts, we need to explicitly transfer the ownership