### PR TITLE
Use openzeppelin contracts version v4.8.0

### DIFF
--- a/src/EspressoSGXTEEVerifier.sol
+++ b/src/EspressoSGXTEEVerifier.sol
@@ -13,6 +13,7 @@ import {EnclaveReport} from "@automata-network/dcap-attestation/contracts/types/
 import {BytesUtils} from "@automata-network/dcap-attestation/contracts/utils/BytesUtils.sol";
 import "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {IEspressoSGXTEEVerifier} from "./interface/IEspressoSGXTEEVerifier.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
 /**
  *

--- a/src/EspressoSGXTEEVerifier.sol
+++ b/src/EspressoSGXTEEVerifier.sol
@@ -13,7 +13,6 @@ import {EnclaveReport} from "@automata-network/dcap-attestation/contracts/types/
 import {BytesUtils} from "@automata-network/dcap-attestation/contracts/utils/BytesUtils.sol";
 import "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {IEspressoSGXTEEVerifier} from "./interface/IEspressoSGXTEEVerifier.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
 
 /**
  *

--- a/src/EspressoSGXTEEVerifier.sol
+++ b/src/EspressoSGXTEEVerifier.sol
@@ -29,12 +29,13 @@ contract EspressoSGXTEEVerifier is IEspressoSGXTEEVerifier, Ownable2Step {
     mapping(bytes32 => bool) public registeredEnclaveHash;
     mapping(address => bool) public registeredSigners;
 
-    constructor(bytes32 enclaveHash, address _quoteVerifier) Ownable(msg.sender) {
+    constructor(bytes32 enclaveHash, address _quoteVerifier) Ownable() {
         if (_quoteVerifier == address(0) || _quoteVerifier.code.length <= 0) {
             revert InvalidQuoteVerifierAddress();
         }
         quoteVerifier = V3QuoteVerifier(_quoteVerifier);
         registeredEnclaveHash[enclaveHash] = true;
+        _transferOwnership(msg.sender);
     }
 
     /*

--- a/src/EspressoTEEVerifier.sol
+++ b/src/EspressoTEEVerifier.sol
@@ -5,7 +5,6 @@ import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {IEspressoSGXTEEVerifier} from "./interface/IEspressoSGXTEEVerifier.sol";
 import {IEspressoTEEVerifier} from "./interface/IEspressoTEEVerifier.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
 
 /**
  * @title EspressoTEEVerifier

--- a/src/EspressoTEEVerifier.sol
+++ b/src/EspressoTEEVerifier.sol
@@ -5,6 +5,7 @@ import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {IEspressoSGXTEEVerifier} from "./interface/IEspressoSGXTEEVerifier.sol";
 import {IEspressoTEEVerifier} from "./interface/IEspressoTEEVerifier.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
 /**
  * @title EspressoTEEVerifier

--- a/src/EspressoTEEVerifier.sol
+++ b/src/EspressoTEEVerifier.sol
@@ -14,8 +14,9 @@ import {IEspressoTEEVerifier} from "./interface/IEspressoTEEVerifier.sol";
 contract EspressoTEEVerifier is Ownable2Step, IEspressoTEEVerifier {
     IEspressoSGXTEEVerifier public espressoSGXTEEVerifier;
 
-    constructor(IEspressoSGXTEEVerifier _espressoSGXTEEVerifier) Ownable(msg.sender) {
+    constructor(IEspressoSGXTEEVerifier _espressoSGXTEEVerifier) Ownable() {
         espressoSGXTEEVerifier = _espressoSGXTEEVerifier;
+        _transferOwnership(msg.sender);
     }
 
     /**

--- a/test/EspressoSGXTEEVerifier.t.sol
+++ b/test/EspressoSGXTEEVerifier.t.sol
@@ -114,9 +114,8 @@ contract EspressoSGXTEEVerifierTest is Test {
 
         // Check that only owner can delete the signer
         vm.startPrank(fakeAddress);
-        vm.expectRevert(
-            abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, fakeAddress)
-        );
+        vm.expectRevert("Ownable: caller is not the owner");
+
         espressoSGXTEEVerifier.deleteRegisteredSigners(batchPosters);
         vm.stopPrank();
     }
@@ -207,9 +206,7 @@ contract EspressoSGXTEEVerifierTest is Test {
         vm.stopPrank();
         // Check that only owner can set the hash
         vm.startPrank(fakeAddress);
-        vm.expectRevert(
-            abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, fakeAddress)
-        );
+        vm.expectRevert("Ownable: caller is not the owner");
         espressoSGXTEEVerifier.setEnclaveHash(newMrEnclave, true);
         vm.stopPrank();
     }

--- a/test/EspressoTEEVerifier.t.sol
+++ b/test/EspressoTEEVerifier.t.sol
@@ -87,9 +87,7 @@ contract EspressoTEEVerifierTest is Test {
         );
         vm.stopPrank();
         vm.startPrank(fakeAddress);
-        vm.expectRevert(
-            abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, fakeAddress)
-        );
+        vm.expectRevert("Ownable: caller is not the owner");
         espressoTEEVerifier.setEspressoSGXTEEVerifier(newEspressoSGXTEEVerifier);
         vm.stopPrank();
     }


### PR DESCRIPTION
Using openzeppelin contracts version v4.8.0 because otherwise it collides with nitro-contracts