### PR TITLE
Expose Address Methods on `Espresso TEEVerifier Interface`

### DIFF
--- a/src/EspressoTEEVerifier.sol
+++ b/src/EspressoTEEVerifier.sol
@@ -6,7 +6,6 @@ import "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {IEspressoSGXTEEVerifier} from "./interface/IEspressoSGXTEEVerifier.sol";
 import {IEspressoNitroTEEVerifier} from "./interface/IEspressoNitroTEEVerifier.sol";
 import {IEspressoTEEVerifier} from "./interface/IEspressoTEEVerifier.sol";
-import {EnclaveReport} from "@automata-network/dcap-attestation/contracts/types/V3Structs.sol";
 
 /**
  * @title EspressoTEEVerifier

--- a/src/interface/IEspressoTEEVerifier.sol
+++ b/src/interface/IEspressoTEEVerifier.sol
@@ -20,6 +20,12 @@ interface IEspressoTEEVerifier {
     // This error is thrown when the TEE type is not supported
     error UnsupportedTeeType();
 
+    // Get address of Nitro TEE Verifier
+    function espressoNitroTEEVerifier() external view returns (IEspressoNitroTEEVerifier);
+
+    // Get addressof SGX TEE Verifier
+    function espressoSGXTEEVerifier() external view returns (IEspressoSGXTEEVerifier);
+
     // Function to verify the signature of the user data is from a registered signer
     function verify(bytes memory signature, bytes32 userDataHash, TeeType teeType)
         external

--- a/test/EspressoTEEVerifier.t.sol
+++ b/test/EspressoTEEVerifier.t.sol
@@ -259,7 +259,8 @@ contract EspressoTEEVerifierTest is Test {
         assertEq(address(espressoNitroTEEVerifier), nitroAddr);
 
         // Test with using EspressoTEEVerifier Interface
-        IEspressoTEEVerifier iespressoTEEVerifier = new EspressoTEEVerifier(espressoSGXTEEVerifier, espressoNitroTEEVerifier);
+        IEspressoTEEVerifier iespressoTEEVerifier =
+            new EspressoTEEVerifier(espressoSGXTEEVerifier, espressoNitroTEEVerifier);
         // Without espressoNitroTEEVerifier() added to interface, the test would fail to compile
         nitroAddr = address(iespressoTEEVerifier.espressoNitroTEEVerifier());
         assertEq(address(espressoNitroTEEVerifier), nitroAddr);
@@ -276,7 +277,8 @@ contract EspressoTEEVerifierTest is Test {
         assertEq(address(espressoSGXTEEVerifier), sgxAddr);
 
         // Test with using EspressoTEEVerifier Interface
-        IEspressoTEEVerifier iespressoTEEVerifier = new EspressoTEEVerifier(espressoSGXTEEVerifier, espressoNitroTEEVerifier);
+        IEspressoTEEVerifier iespressoTEEVerifier =
+            new EspressoTEEVerifier(espressoSGXTEEVerifier, espressoNitroTEEVerifier);
         // Without espressoSGXTEEVerifier() added to interface, the test would fail to compile
         sgxAddr = address(iespressoTEEVerifier.espressoSGXTEEVerifier());
         assertEq(address(espressoSGXTEEVerifier), sgxAddr);

--- a/test/EspressoTEEVerifier.t.sol
+++ b/test/EspressoTEEVerifier.t.sol
@@ -250,19 +250,37 @@ contract EspressoTEEVerifierTest is Test {
         vm.stopPrank();
     }
 
-    // Test Address retrieval nitro
+    // Test Address retrieval Nitro
     function testAddressRetrievalNitro() public {
         vm.startPrank(adminTEE);
+
+        // Test without using interface
         address nitroAddr = address(espressoTEEVerifier.espressoNitroTEEVerifier());
         assertEq(address(espressoNitroTEEVerifier), nitroAddr);
+
+        // Test with using EspressoTEEVerifier Interface
+        IEspressoTEEVerifier iespressoTEEVerifier = new EspressoTEEVerifier(espressoSGXTEEVerifier, espressoNitroTEEVerifier);
+        // Without espressoNitroTEEVerifier() added to interface, the test would fail to compile
+        nitroAddr = address(iespressoTEEVerifier.espressoNitroTEEVerifier());
+        assertEq(address(espressoNitroTEEVerifier), nitroAddr);
+
         vm.stopPrank();
     }
 
-    // Test Address retrieval sgx
+    // Test Address retrieval SGX
     function testAddressRetrievalSGX() public {
         vm.startPrank(adminTEE);
+
+        // Test without using interface
         address sgxAddr = address(espressoTEEVerifier.espressoSGXTEEVerifier());
         assertEq(address(espressoSGXTEEVerifier), sgxAddr);
+
+        // Test with using EspressoTEEVerifier Interface
+        IEspressoTEEVerifier iespressoTEEVerifier = new EspressoTEEVerifier(espressoSGXTEEVerifier, espressoNitroTEEVerifier);
+        // Without espressoSGXTEEVerifier() added to interface, the test would fail to compile
+        sgxAddr = address(iespressoTEEVerifier.espressoSGXTEEVerifier());
+        assertEq(address(espressoSGXTEEVerifier), sgxAddr);
+
         vm.stopPrank();
     }
 }


### PR DESCRIPTION
Helps unblock this ticket
https://app.asana.com/1/1208976916964769/project/1209976130071762/task/1209471306729260
<!-- These comments should help create a useful PR message, please delete any remaining comments before opening the PR. -->
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->
When we generate the `go` bindings for the `EspressoTEEVerifier` we get the interface bindings. There is no way to access the address of `espressoSGXTEEVerifier` and `espressoNitroTEEVerifier`. We need to expose these methods on the interface in order to do so.
### This PR does not:
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->

### Key places to review:
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->

<!-- ### How to test this PR:  -->
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

<!-- ### Things tested -->
<!-- Anything that was manually tested (that is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] Documentation for changes (additions) has been updated (added).  -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
