### PR TITLE
Remove Salt

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 Foundry consists of:
 
--   **Forge**: Ethereum testing framework (like Truffle, Hardhat and DappTools).
--   **Cast**: Swiss army knife for interacting with EVM smart contracts, sending transactions and getting chain data.
--   **Anvil**: Local Ethereum node, akin to Ganache, Hardhat Network.
--   **Chisel**: Fast, utilitarian, and verbose solidity REPL.
+- **Forge**: Ethereum testing framework (like Truffle, Hardhat and DappTools).
+- **Cast**: Swiss army knife for interacting with EVM smart contracts, sending transactions and getting chain data.
+- **Anvil**: Local Ethereum node, akin to Ganache, Hardhat Network.
+- **Chisel**: Fast, utilitarian, and verbose solidity REPL.
 
 ## Documentation
 
@@ -62,12 +62,15 @@ $ cast --help
 ## TEE Verifier Deployment
 
 ### 1. Clean Build Environment
- Start with a fresh build to ensure as we need to build contracts with proper profiles for gas optimizations:
-   ```bash
-   forge clean
-   ```
-  
+
+Start with a fresh build to ensure as we need to build contracts with proper profiles for gas optimizations:
+
+```bash
+forge clean
+```
+
 ### 2. **Environment Setup**
+
 Create a `.env` file in the project root with the following variables:
 
 ```text
@@ -88,7 +91,6 @@ NITRO_VERIFIER_ADDRESS=""
 SGX_VERIFIER_ADDRESS=""
 ```
 
-
 Save the file then source it:
 
 ```bash
@@ -96,49 +98,68 @@ source .env
 ```
 
 ### 3. **Deployment Process**
+
+1. If CertManager is not deployed on the given chain, deploy it first:
+   ```bash
+   FOUNDRY_PROFILE=nitro forge script scripts/DeployCertManager.sol:DeployCertManager \
+       --rpc-url "$RPC_URL" \
+       --private-key "$PRIVATE_KEY" \
+       --chain-id "$CHAIN_ID" \
+       --etherscan-api-key "$ETHERSCAN_API_KEY"  \
+       --broadcast \
+       --verify
+   ```
 1. **Deploy Nitro Verifier**
-    ```bash
-    FOUNDRY_PROFILE=nitro forge script scripts/DeployNitroTEEVerifier.s.sol:DeployNitroTEEVerifier \
-        --contracts src/EspressoNitroTEEVerifier.sol \
-        --rpc-url "$RPC_URL" \
-        --private-key "$PRIVATE_KEY" \
-        --chain-id "$CHAIN_ID" \
-        --etherscan-api-key "$ETHERSCAN_API_KEY"  \
-        --broadcast \
-        --verify
-    ```
-2. **Deploy SGX Verifier**
-    ```bash
-    FOUNDRY_PROFILE=sgx forge script scripts/DeploySGXTEEVerifier.s.sol:DeploySGXTEEVerifier \
-        --contracts src/EspressoSGXTEEVerifier.sol \
-        --skip src/EspressoNitroTEEVerifier.sol \
-        --rpc-url "$RPC_URL" \
-        --private-key "$PRIVATE_KEY" \
-        --chain-id "$CHAIN_ID" \
-        --etherscan-api-key "$ETHERSCAN_API_KEY"  \
-        --broadcast \
-        --verify
-    ```
+   After CertManager deployment update the `.env` file with:
+   ```text
+   CERT_MANAGER_ADDRESS=<deployed_cert_manager_address>
+   ```
+   then execute:
+   ```bash
+   FOUNDRY_PROFILE=nitro forge script scripts/DeployNitroTEEVerifier.s.sol:DeployNitroTEEVerifier \
+       --contracts src/EspressoNitroTEEVerifier.sol \
+       --rpc-url "$RPC_URL" \
+       --private-key "$PRIVATE_KEY" \
+       --chain-id "$CHAIN_ID" \
+       --etherscan-api-key "$ETHERSCAN_API_KEY"  \
+       --broadcast \
+       --verify
+   ```
+1. **Deploy SGX Verifier**
 
-3. **Update Environment Variables**
+   ```bash
+   FOUNDRY_PROFILE=sgx forge script scripts/DeploySGXTEEVerifier.s.sol:DeploySGXTEEVerifier \
+       --contracts src/EspressoSGXTEEVerifier.sol \
+       --skip src/EspressoNitroTEEVerifier.sol \
+       --rpc-url "$RPC_URL" \
+       --private-key "$PRIVATE_KEY" \
+       --chain-id "$CHAIN_ID" \
+       --etherscan-api-key "$ETHERSCAN_API_KEY"  \
+       --broadcast \
+       --verify
+   ```
 
-    After successful AWS Nitro and SGX deployments update the `.env` file with:
+1. **Update Environment Variables**
 
-    ```text
-    NITRO_VERIFIER_ADDRESS=<deployed_nitro_address>
-    SGX_VERIFIER_ADDRESS=<deployed_sgx_address>
-    ```
+   After successful AWS Nitro and SGX deployments update the `.env` file with:
 
-4. **Deploy Espresso TEE Verifier**
-    ```bash
-    forge script scripts/DeployTEEVerifier.s.sol:DeployTEEVerifier \
-        --contracts src/EspressoTEEVerifier.sol \
-        --rpc-url "$RPC_URL" \
-        --private-key "$PRIVATE_KEY" \
-        --chain-id "$CHAIN_ID" \
-        --etherscan-api-key "$ETHERSCAN_API_KEY"  \
-        --broadcast \
-        --verify
-    ```
+   ```text
+   NITRO_VERIFIER_ADDRESS=<deployed_nitro_address>
+   SGX_VERIFIER_ADDRESS=<deployed_sgx_address>
+   ```
+
+1. **Deploy Espresso TEE Verifier**
+   ```bash
+   forge script scripts/DeployTEEVerifier.s.sol:DeployTEEVerifier \
+       --contracts src/EspressoTEEVerifier.sol \
+       --rpc-url "$RPC_URL" \
+       --private-key "$PRIVATE_KEY" \
+       --chain-id "$CHAIN_ID" \
+       --etherscan-api-key "$ETHERSCAN_API_KEY"  \
+       --broadcast \
+       --verify
+   ```
+
 ### 4. Post-Deployment
+
 Verify all contracts on Block Explorer and ensure deployment artifacts are in deployments/<chain_id>/

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ source .env
 
 1. If CertManager is not deployed on the given chain, deploy it first:
    ```bash
-   FOUNDRY_PROFILE=nitro forge script scripts/DeployCertManager.sol:DeployCertManager \
+    forge script scripts/DeployCertManager.sol:DeployCertManager \
        --rpc-url "$RPC_URL" \
        --private-key "$PRIVATE_KEY" \
        --chain-id "$CHAIN_ID" \
@@ -109,7 +109,7 @@ source .env
        --broadcast \
        --verify
    ```
-1. **Deploy Nitro Verifier**
+2. **Deploy Nitro Verifier**
    After CertManager deployment update the `.env` file with:
    ```text
    CERT_MANAGER_ADDRESS=<deployed_cert_manager_address>
@@ -125,7 +125,7 @@ source .env
        --broadcast \
        --verify
    ```
-1. **Deploy SGX Verifier**
+3. **Deploy SGX Verifier**
 
    ```bash
    FOUNDRY_PROFILE=sgx forge script scripts/DeploySGXTEEVerifier.s.sol:DeploySGXTEEVerifier \
@@ -139,7 +139,7 @@ source .env
        --verify
    ```
 
-1. **Update Environment Variables**
+4. **Update Environment Variables**
 
    After successful AWS Nitro and SGX deployments update the `.env` file with:
 
@@ -148,7 +148,7 @@ source .env
    SGX_VERIFIER_ADDRESS=<deployed_sgx_address>
    ```
 
-1. **Deploy Espresso TEE Verifier**
+5. **Deploy Espresso TEE Verifier**
    ```bash
    forge script scripts/DeployTEEVerifier.s.sol:DeployTEEVerifier \
        --contracts src/EspressoTEEVerifier.sol \

--- a/scripts/DeployCertManager.sol
+++ b/scripts/DeployCertManager.sol
@@ -1,0 +1,21 @@
+pragma solidity ^0.8.25;
+import {Script} from "forge-std/Script.sol";
+import {console2} from "forge-std/console2.sol";
+import {CertManager} from "@nitro-validator/CertManager.sol";
+
+contract DeployCertManager is Script {
+    function run() external {
+        vm.startBroadcast();
+        CertManager certManager = new CertManager();
+        console2.log("CertManager deployed at:", address(certManager));
+
+        // Vm string CertManager address
+        string memory chainId = vm.toString(block.chainid);
+        string memory dir = string.concat(vm.projectRoot(), "/deployments");
+        vm.writeJson(
+            vm.serializeAddress("", "CertManager", address(certManager)),
+            string.concat(dir, "/", chainId, "-cert-manager.json")
+        );
+        vm.stopBroadcast();
+    }
+}

--- a/scripts/DeployNitroTEEVerifier.s.sol
+++ b/scripts/DeployNitroTEEVerifier.s.sol
@@ -6,32 +6,31 @@ import {EspressoNitroTEEVerifier} from "src/EspressoNitroTEEVerifier.sol";
 import {IEspressoNitroTEEVerifier} from "src/interface/IEspressoNitroTEEVerifier.sol";
 
 contract DeployNitroTEEVerifier is Script {
-
     function run() external {
         vm.startBroadcast();
 
-        string memory salt = vm.envString("CERT_MANAGER_SALT");
-        require(bytes(salt).length > 0, "CERT_MANAGER_SALT environment variable not set");
-        bytes32 CERT_MANAGER_SALT = keccak256(abi.encodePacked(salt));
+        address certManager = vm.envAddress("CERT_MANAGER_ADDRESS");
+        require(
+            certManager != address(0),
+            "CERT_MANAGER_ADDRESS environment variable not set or invalid"
+        );
         bytes32 pcr0Hash = vm.envBytes32("NITRO_ENCLAVE_HASH");
-        require(pcr0Hash != bytes32(0), "NITRO_ENCLAVE_HASH environment variable not set or invalid");
+        require(
+            pcr0Hash != bytes32(0),
+            "NITRO_ENCLAVE_HASH environment variable not set or invalid"
+        );
 
-
-        // 1. Deploy CertManager
-        CertManager certManager = new CertManager{salt: CERT_MANAGER_SALT}();
-        console2.log("CertManager deployed at:", address(certManager));
-
-        // 2. Deploy NitroVerifier
+        // 1. Deploy NitroVerifier
         IEspressoNitroTEEVerifier nitroVerifier = new EspressoNitroTEEVerifier(
             pcr0Hash,
-            certManager
+            CertManager(certManager)
         );
         console2.log("NitroVerifier deployed at:", address(nitroVerifier));
 
         // Save deployment artifacts
         string memory chainId = vm.toString(block.chainid);
         string memory dir = string.concat(vm.projectRoot(), "/deployments");
-        
+
         // Write CertManager address
         vm.writeJson(
             vm.serializeAddress("", "CertManager", address(certManager)),
@@ -40,7 +39,11 @@ contract DeployNitroTEEVerifier is Script {
 
         // Write NitroVerifier address
         vm.writeJson(
-            vm.serializeAddress("", "EspressoNitroTEEVerifier", address(nitroVerifier)),
+            vm.serializeAddress(
+                "",
+                "EspressoNitroTEEVerifier",
+                address(nitroVerifier)
+            ),
             string.concat(dir, "/", chainId, "-nitro-verifier.json")
         );
 

--- a/scripts/DeploySGXTEEVerifier.s.sol
+++ b/scripts/DeploySGXTEEVerifier.s.sol
@@ -1,11 +1,10 @@
+pragma solidity ^0.8.25;
 import {Script} from "forge-std/Script.sol";
 import {console2} from "forge-std/console2.sol";
 import {EspressoSGXTEEVerifier} from "src/EspressoSGXTEEVerifier.sol";
 import {IEspressoSGXTEEVerifier} from "src/interface/IEspressoSGXTEEVerifier.sol";
 
 contract DeploySGXTEEVerifier is Script {
-    bytes32 constant SGX_VERIFIER_SALT = keccak256("espresso.sgxverifier.v1");
-
     function run() external {
         vm.startBroadcast();
         bytes32 enclaveHash = vm.envBytes32("SGX_ENCLAVE_HASH");
@@ -14,7 +13,7 @@ contract DeploySGXTEEVerifier is Script {
         require(quoteVerifierAddr != address(0), "SGX_QUOTE_VERIFIER_ADDRESS environment variable not set or invalid");
 
         // Deploy SGX Verifier
-        IEspressoSGXTEEVerifier sgxVerifier = new EspressoSGXTEEVerifier{salt: SGX_VERIFIER_SALT}(
+        IEspressoSGXTEEVerifier sgxVerifier = new EspressoSGXTEEVerifier(
             enclaveHash,
             quoteVerifierAddr
         );


### PR DESCRIPTION
Removing salt from CertManager and SGX contract when deploying these contracts because otherwise it was making the Create2 contract the owner which we dont want. Also CertManager doesnt need to be deployed multiple times for a given chain