### PR TITLE
Small Fixes to disable via-ir

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 [submodule "lib/automata-dcap-attestation"]
 	path = lib/automata-dcap-attestation
 	url = https://github.com/EspressoSystems/automata-dcap-attestation
-	branch = espresso-nitro
+	branch = fix-via-ir-automata
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 [submodule "lib/automata-dcap-attestation"]
 	path = lib/automata-dcap-attestation
 	url = https://github.com/EspressoSystems/automata-dcap-attestation
-	branch = fix-via-ir-automata
+	branch = espresso-nitro
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/foundry.toml
+++ b/foundry.toml
@@ -19,7 +19,7 @@ libs = [ 'lib']
 optimizer = true
 optimizer_runs = 1
 optimizer_details = { yul = true }
-via_ir = true
+via_ir = false
 solc_version = '0.8.25'
 fs_permissions = [
     { access = "read", path = "./"},

--- a/src/interface/IEspressoTEEVerifier.sol
+++ b/src/interface/IEspressoTEEVerifier.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {Header} from "@automata-network/dcap-attestation/contracts/types/CommonStruct.sol";
-import {EnclaveReport} from "@automata-network/dcap-attestation/contracts/types/V3Structs.sol";
 import {IEspressoSGXTEEVerifier} from "./IEspressoSGXTEEVerifier.sol";
 import {IEspressoNitroTEEVerifier} from "./IEspressoNitroTEEVerifier.sol";
 


### PR DESCRIPTION
Removing via ir from the repo so that its easier to compile Offchain labs code and make verification also work with foundry