### PR TITLE
Update Contract Verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Espresso TEE Contracts
+
 ## Foundry
 
 **Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.**
@@ -11,52 +13,52 @@ Foundry consists of:
 
 ## Documentation
 
-https://book.getfoundry.sh/
+Download foundry at `https://book.getfoundry.sh/`
 
 ## Usage
 
 ### Build
 
 ```shell
-$ forge build
+forge build
 ```
 
 ### Test
 
 ```shell
-$ forge test
+forge test
 ```
 
 ### Format
 
 ```shell
-$ forge fmt
+forge fmt
 ```
 
 ### Gas Snapshots
 
 ```shell
-$ forge snapshot
+forge snapshot
 ```
 
 ### Anvil
 
 ```shell
-$ anvil
+anvil
 ```
 
 ### Cast
 
 ```shell
-$ cast <subcommand>
+cast <subcommand>
 ```
 
 ### Help
 
 ```shell
-$ forge --help
-$ anvil --help
-$ cast --help
+forge --help
+anvil --help
+cast --help
 ```
 
 ## TEE Verifier Deployment
@@ -71,22 +73,25 @@ forge clean
 
 ### 2. **Environment Setup**
 
-Create a `.env` file in the project root with the following variables:
+Create a `.env` file in the project root with the following variables.
+The `ETHERSCAN_API_KEY` should be generated from your account on [etherscan.io](https://etherscan.io/myapikey) and works across all supported chains via the V2 API.
 
 ```text
 # Variables for script command
 RPC_URL=<your-rpc-url>
 PRIVATE_KEY=<your-private-key>
 CHAIN_ID=<your-chain-id>
-ETHERSCAN_API_KEY=<your-api-key>
+
+# Etherscan V2 API Key from etherscan.io (works for all chains)
+ETHERSCAN_API_KEY=<your-etherscan-v2-api-key>
 
 # Variables for deployment
-CERT_MANAGER_SALT=<your_salt_here>
 NITRO_ENCLAVE_HASH=<aws_nitro_pcr0_hash>
 SGX_ENCLAVE_HASH=<sgx_enclave_measurement>
 SGX_QUOTE_VERIFIER_ADDRESS=<quote_verifier_address_from_automata>  # From: https://github.com/automata-network/automata-dcap-attestation
 
 # To be updated after deployment
+CERT_MANAGER_ADDRESS=""
 NITRO_VERIFIER_ADDRESS=""
 SGX_VERIFIER_ADDRESS=""
 ```
@@ -100,43 +105,40 @@ source .env
 ### 3. **Deployment Process**
 
 1. If CertManager is not deployed on the given chain, deploy it first:
+
    ```bash
     forge script scripts/DeployCertManager.sol:DeployCertManager \
        --rpc-url "$RPC_URL" \
        --private-key "$PRIVATE_KEY" \
-       --chain-id "$CHAIN_ID" \
-       --etherscan-api-key "$ETHERSCAN_API_KEY"  \
        --broadcast \
-       --verify
+       --verify --verifier etherscan
    ```
+
 2. **Deploy Nitro Verifier**
    After CertManager deployment update the `.env` file with:
+
    ```text
    CERT_MANAGER_ADDRESS=<deployed_cert_manager_address>
    ```
+
    then execute:
+
    ```bash
    FOUNDRY_PROFILE=nitro forge script scripts/DeployNitroTEEVerifier.s.sol:DeployNitroTEEVerifier \
-       --contracts src/EspressoNitroTEEVerifier.sol \
        --rpc-url "$RPC_URL" \
        --private-key "$PRIVATE_KEY" \
-       --chain-id "$CHAIN_ID" \
-       --etherscan-api-key "$ETHERSCAN_API_KEY"  \
        --broadcast \
-       --verify
+       --verify --verifier etherscan
    ```
+
 3. **Deploy SGX Verifier**
 
    ```bash
    FOUNDRY_PROFILE=sgx forge script scripts/DeploySGXTEEVerifier.s.sol:DeploySGXTEEVerifier \
-       --contracts src/EspressoSGXTEEVerifier.sol \
-       --skip src/EspressoNitroTEEVerifier.sol \
        --rpc-url "$RPC_URL" \
        --private-key "$PRIVATE_KEY" \
-       --chain-id "$CHAIN_ID" \
-       --etherscan-api-key "$ETHERSCAN_API_KEY"  \
        --broadcast \
-       --verify
+       --verify --verifier etherscan
    ```
 
 4. **Update Environment Variables**
@@ -149,15 +151,13 @@ source .env
    ```
 
 5. **Deploy Espresso TEE Verifier**
+
    ```bash
    forge script scripts/DeployTEEVerifier.s.sol:DeployTEEVerifier \
-       --contracts src/EspressoTEEVerifier.sol \
        --rpc-url "$RPC_URL" \
        --private-key "$PRIVATE_KEY" \
-       --chain-id "$CHAIN_ID" \
-       --etherscan-api-key "$ETHERSCAN_API_KEY"  \
        --broadcast \
-       --verify
+       --verify --verifier etherscan
    ```
 
 ### 4. Post-Deployment

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ source .env
        --rpc-url "$RPC_URL" \
        --private-key "$PRIVATE_KEY" \
        --broadcast \
-       --verify --verifier etherscan
+       --verify --verifier etherscan --chain "$CHAIN_ID"
    ```
 
 2. **Deploy Nitro Verifier**
@@ -128,7 +128,7 @@ source .env
        --rpc-url "$RPC_URL" \
        --private-key "$PRIVATE_KEY" \
        --broadcast \
-       --verify --verifier etherscan
+       --verify --verifier etherscan --chain "$CHAIN_ID"
    ```
 
 3. **Deploy SGX Verifier**
@@ -138,7 +138,7 @@ source .env
        --rpc-url "$RPC_URL" \
        --private-key "$PRIVATE_KEY" \
        --broadcast \
-       --verify --verifier etherscan
+       --verify --verifier etherscan --chain "$CHAIN_ID"
    ```
 
 4. **Update Environment Variables**
@@ -157,7 +157,7 @@ source .env
        --rpc-url "$RPC_URL" \
        --private-key "$PRIVATE_KEY" \
        --broadcast \
-       --verify --verifier etherscan
+       --verify --verifier etherscan --chain "$CHAIN_ID"
    ```
 
 ### 4. Post-Deployment

--- a/foundry.toml
+++ b/foundry.toml
@@ -45,4 +45,4 @@ line_length = 100
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config
 
 [etherscan]
-etherscan = { key = "${ETHERSCAN_API_KEY}", chain = "${CHAIN_ID}", url = "https://api.etherscan.io/api" }
+etherscan = { key = "${ETHERSCAN_API_KEY}", url = "https://api.etherscan.io/api" }

--- a/foundry.toml
+++ b/foundry.toml
@@ -44,3 +44,5 @@ number_underscore = 'thousands'
 line_length = 100
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config
 
+[etherscan]
+etherscan = { key = "${ETHERSCAN_API_KEY}", chain = "${CHAIN_ID}", url = "https://api.etherscan.io/api" }

--- a/scripts/DeployNitroTEEVerifier.s.sol
+++ b/scripts/DeployNitroTEEVerifier.s.sol
@@ -31,12 +31,6 @@ contract DeployNitroTEEVerifier is Script {
         string memory chainId = vm.toString(block.chainid);
         string memory dir = string.concat(vm.projectRoot(), "/deployments");
 
-        // Write CertManager address
-        vm.writeJson(
-            vm.serializeAddress("", "CertManager", address(certManager)),
-            string.concat(dir, "/", chainId, "-certmanager.json")
-        );
-
         // Write NitroVerifier address
         vm.writeJson(
             vm.serializeAddress(


### PR DESCRIPTION
This pull request updates the `README.md` documentation and contract verification.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R2): Updated `.env` file setup instructions to include details about generating an `ETHERSCAN_API_KEY`.

### Deployment Process:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R108-R141): Updated deployment commands to use `--verify --verifier etherscan` instead of manually specifying `--etherscan-api-key`. Removed redundant parameters like `--chain-id` and `--contracts` from deployment scripts for CertManager, Nitro Verifier, SGX Verifier, and Espresso TEE Verifier. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R108-R141) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R154-R160)
* [`foundry.toml`](diffhunk://#diff-bac743fe3d899998e32393af53af8cc7d28c89c3d7fabfa48b01361cf8d42d9bR47-R48): Added an `[etherscan]` section to centralize Etherscan configuration, including API key, and URL. This simplifies integration with Etherscan for verification.

### Deployment Script Refinements:
* [`scripts/DeployNitroTEEVerifier.s.sol`](diffhunk://#diff-86e39af1feb2e68e9af9570cd196a33bb8a314386cdec06efddc8e9ab84c65cbL34-L39): Removed redundant code for writing CertManager address to JSON files during deployment.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210848250793879