### PR TITLE
Rollup Sequencer Manager

### DIFF
--- a/src/EspressoNitroTEEVerifier.sol
+++ b/src/EspressoNitroTEEVerifier.sol
@@ -1,4 +1,4 @@
-// // SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import {NitroValidator} from "@nitro-validator/NitroValidator.sol";

--- a/src/EspressoRollupSequencerManager.sol
+++ b/src/EspressoRollupSequencerManager.sol
@@ -3,24 +3,31 @@ pragma solidity ^0.8.0;
 
 import {RedBlackTreeLib} from "solady/utils/RedBlackTreeLib.sol";
 import "@openzeppelin/contracts/access/Ownable2Step.sol";
+import {IEspressoRollupSequencerManager} from "./interface/IEspressoRollupSequencerManager.sol";
 
-contract EspressoRollupSequencerManager is Ownable2Step {
+contract EspressoRollupSequencerManager is
+    Ownable2Step,
+    IEspressoRollupSequencerManager
+{
     // Initialize the sequencer list as a binary red-black tree
+    using RedBlackTreeLib for RedBlackTreeLib.Tree;
     RedBlackTreeLib.Tree sequencersList;
-    // Thrown when the address is a contract
-    error InvalidSequencer();
-    error SequencerAlreadyExists();
-    error SequencerDoesNotExist();
-    error Unauthorized();
 
     // Create a hashMap to manage the nonce and the sequencer address
     mapping(uint256 => address) public nonceToSequencer;
     mapping(address => uint256) public sequencerToNonce;
 
     // Maintain a global counter to keep track of the nonce
-    uint256 public globalNonce;
+    uint256 public globalNonce = 1;
     // Also maintain a counter to store the current number of sequencers
     uint256 public currentSequencerCount;
+
+    modifier onlyOwnerOrSequencer(address sequencer) {
+        if (msg.sender != owner() && msg.sender != sequencer) {
+            revert Unauthorized();
+        }
+        _;
+    }
 
     constructor(address[] memory initialSequencers) Ownable() {
         _transferOwnership(msg.sender);
@@ -33,7 +40,9 @@ contract EspressoRollupSequencerManager is Ownable2Step {
         @notice Insert a new sequencer into the list
         @param sequencer The address of the sequencer
      */
-    function insertSequencer(address sequencer) public {
+    function insertSequencer(
+        address sequencer
+    ) public onlyOwnerOrSequencer(sequencer) {
         // Check address is not a contract,
         // currently we only support EOAs
         if (sequencer.code.length > 0) {
@@ -41,7 +50,7 @@ contract EspressoRollupSequencerManager is Ownable2Step {
         }
 
         // Check if the sequencer already exist
-        if (sequencerToNonce[sequencer] != 0) {
+        if (sequencerToNonce[sequencer] > 0) {
             revert SequencerAlreadyExists();
         }
 
@@ -53,13 +62,16 @@ contract EspressoRollupSequencerManager is Ownable2Step {
         sequencerToNonce[sequencer] = globalNonce;
         globalNonce++;
         currentSequencerCount++;
+        emit SequencerAdded(sequencer);
     }
 
     /**
         @notice Remove a sequencer from the list
         @param sequencer The address of the sequencer
      */
-    function removeSequencer(address sequencer) external {
+    function removeSequencer(
+        address sequencer
+    ) external onlyOwnerOrSequencer(sequencer) {
         // Check that msg.sender should be the owner or the address of sequencer
         if (msg.sender != owner() && msg.sender != sequencer) {
             revert Unauthorized();
@@ -77,10 +89,13 @@ contract EspressoRollupSequencerManager is Ownable2Step {
         delete nonceToSequencer[nonce];
         delete sequencerToNonce[sequencer];
         currentSequencerCount--;
+        emit SequencerRemoved(sequencer);
     }
 
     /**
         @notice Get the current sequencer for a given view number
+        This function is supposed to be called off-chain because
+        it is computationally expensive
         @param viewNumber The view number
      */
     function getCurrentSequencer(
@@ -92,17 +107,17 @@ contract EspressoRollupSequencerManager is Ownable2Step {
         bytes32 sequencerLocation = sequencersList.first();
         uint256 sequencerValue;
 
+        // get the first sequencer value
         if (index == 0) {
-            // get the first sequencer value
-            sequencerValue = sequencersList.value(sequencerLocation);
+            sequencerValue = RedBlackTreeLib.value(sequencerLocation);
             return nonceToSequencer[sequencerValue];
         }
 
         for (uint256 i = 1; i <= index; i++) {
-            sequencerLocation = sequencersList.next(sequencerLocation);
+            sequencerLocation = RedBlackTreeLib.next(sequencerLocation);
         }
 
-        sequencerValue = sequencersList.value(sequencerLocation);
+        sequencerValue = RedBlackTreeLib.value(sequencerLocation);
         return nonceToSequencer[sequencerValue];
     }
 }

--- a/src/EspressoRollupSequencerManager.sol
+++ b/src/EspressoRollupSequencerManager.sol
@@ -5,12 +5,10 @@ import {RedBlackTreeLib} from "solady/utils/RedBlackTreeLib.sol";
 import "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {IEspressoRollupSequencerManager} from "./interface/IEspressoRollupSequencerManager.sol";
 
-contract EspressoRollupSequencerManager is
-    Ownable2Step,
-    IEspressoRollupSequencerManager
-{
+contract EspressoRollupSequencerManager is Ownable2Step, IEspressoRollupSequencerManager {
     // Initialize the sequencer list as a binary red-black tree
     using RedBlackTreeLib for RedBlackTreeLib.Tree;
+
     RedBlackTreeLib.Tree sequencersList;
 
     // Create a hashMap to manage the nonce and the sequencer address
@@ -37,12 +35,10 @@ contract EspressoRollupSequencerManager is
     }
 
     /**
-        @notice Insert a new sequencer into the list
-        @param sequencer The address of the sequencer
+     * @notice Insert a new sequencer into the list
+     *     @param sequencer The address of the sequencer
      */
-    function insertSequencer(
-        address sequencer
-    ) public onlyOwnerOrSequencer(sequencer) {
+    function insertSequencer(address sequencer) public onlyOwnerOrSequencer(sequencer) {
         // Check address is not a contract,
         // currently we only support EOAs
         if (sequencer.code.length > 0) {
@@ -66,12 +62,10 @@ contract EspressoRollupSequencerManager is
     }
 
     /**
-        @notice Remove a sequencer from the list
-        @param sequencer The address of the sequencer
+     * @notice Remove a sequencer from the list
+     *     @param sequencer The address of the sequencer
      */
-    function removeSequencer(
-        address sequencer
-    ) external onlyOwnerOrSequencer(sequencer) {
+    function removeSequencer(address sequencer) external onlyOwnerOrSequencer(sequencer) {
         // Check that msg.sender should be the owner or the address of sequencer
         if (msg.sender != owner() && msg.sender != sequencer) {
             revert Unauthorized();
@@ -93,14 +87,12 @@ contract EspressoRollupSequencerManager is
     }
 
     /**
-        @notice Get the current sequencer for a given view number
-        This function is supposed to be called off-chain because
-        it is computationally expensive
-        @param viewNumber The view number
+     * @notice Get the current sequencer for a given view number
+     *     This function is supposed to be called off-chain because
+     *     it is computationally expensive
+     *     @param viewNumber The view number
      */
-    function getCurrentSequencer(
-        uint256 viewNumber
-    ) external view returns (address) {
+    function getCurrentSequencer(uint256 viewNumber) external view returns (address) {
         // Take the mod of the viewNumber and the currentSequencerCount
         uint256 index = viewNumber % currentSequencerCount;
         // First get the first sequencer

--- a/src/EspressoRollupSequencerManager.sol
+++ b/src/EspressoRollupSequencerManager.sol
@@ -1,0 +1,108 @@
+// // SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {RedBlackTreeLib} from "solady/utils/RedBlackTreeLib.sol";
+import "@openzeppelin/contracts/access/Ownable2Step.sol";
+
+contract EspressoRollupSequencerManager is Ownable2Step {
+    // Initialize the sequencer list as a binary red-black tree
+    RedBlackTreeLib.Tree sequencersList;
+    // Thrown when the address is a contract
+    error InvalidSequencer();
+    error SequencerAlreadyExists();
+    error SequencerDoesNotExist();
+    error Unauthorized();
+
+    // Create a hashMap to manage the nonce and the sequencer address
+    mapping(uint256 => address) public nonceToSequencer;
+    mapping(address => uint256) public sequencerToNonce;
+
+    // Maintain a global counter to keep track of the nonce
+    uint256 public globalNonce;
+    // Also maintain a counter to store the current number of sequencers
+    uint256 public currentSequencerCount;
+
+    constructor(address[] memory initialSequencers) Ownable() {
+        _transferOwnership(msg.sender);
+        for (uint256 i = 0; i < initialSequencers.length; i++) {
+            insertSequencer(initialSequencers[i]);
+        }
+    }
+
+    /**
+        @notice Insert a new sequencer into the list
+        @param sequencer The address of the sequencer
+     */
+    function insertSequencer(address sequencer) public {
+        // Check address is not a contract,
+        // currently we only support EOAs
+        if (sequencer.code.length > 0) {
+            revert InvalidSequencer();
+        }
+
+        // Check if the sequencer already exist
+        if (sequencerToNonce[sequencer] != 0) {
+            revert SequencerAlreadyExists();
+        }
+
+        // Insert the sequencer into the list,
+        // If the address already exist, it will throw an error
+        sequencersList.insert(globalNonce);
+        // Store the mappings
+        nonceToSequencer[globalNonce] = sequencer;
+        sequencerToNonce[sequencer] = globalNonce;
+        globalNonce++;
+        currentSequencerCount++;
+    }
+
+    /**
+        @notice Remove a sequencer from the list
+        @param sequencer The address of the sequencer
+     */
+    function removeSequencer(address sequencer) external {
+        // Check that msg.sender should be the owner or the address of sequencer
+        if (msg.sender != owner() && msg.sender != sequencer) {
+            revert Unauthorized();
+        }
+
+        // Check if the sequencer exists
+        if (sequencerToNonce[sequencer] == 0) {
+            revert SequencerDoesNotExist();
+        }
+
+        // Remove the sequencer from the list
+        uint256 nonce = sequencerToNonce[sequencer];
+        sequencersList.remove(nonce);
+        // Delete the mappings
+        delete nonceToSequencer[nonce];
+        delete sequencerToNonce[sequencer];
+        currentSequencerCount--;
+    }
+
+    /**
+        @notice Get the current sequencer for a given view number
+        @param viewNumber The view number
+     */
+    function getCurrentSequencer(
+        uint256 viewNumber
+    ) external view returns (address) {
+        // Take the mod of the viewNumber and the currentSequencerCount
+        uint256 index = viewNumber % currentSequencerCount;
+        // First get the first sequencer
+        bytes32 sequencerLocation = sequencersList.first();
+        uint256 sequencerValue;
+
+        if (index == 0) {
+            // get the first sequencer value
+            sequencerValue = sequencersList.value(sequencerLocation);
+            return nonceToSequencer[sequencerValue];
+        }
+
+        for (uint256 i = 1; i <= index; i++) {
+            sequencerLocation = sequencersList.next(sequencerLocation);
+        }
+
+        sequencerValue = sequencersList.value(sequencerLocation);
+        return nonceToSequencer[sequencerValue];
+    }
+}

--- a/src/interface/IEspressoRollupSequencerManager.sol
+++ b/src/interface/IEspressoRollupSequencerManager.sol
@@ -2,11 +2,12 @@
 pragma solidity ^0.8.0;
 
 interface IEspressoRollupSequencerManager {
-    event SequencerAdded(address indexed sequencer);
-    event SequencerRemoved(address indexed sequencer);
+    event SequencerAdded(address indexed sequencer, uint256 indexed nonce);
+    event SequencerRemoved(address indexed sequencer, uint256 indexed nonce);
 
     error InvalidSequencer();
     error SequencerAlreadyExists();
+    error SequencerListIsEmpty();
     error SequencerDoesNotExist();
     error Unauthorized();
 

--- a/src/interface/IEspressoRollupSequencerManager.sol
+++ b/src/interface/IEspressoRollupSequencerManager.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IEspressoRollupSequencerManager {
+    event SequencerAdded(address indexed sequencer);
+    event SequencerRemoved(address indexed sequencer);
+
+    error InvalidSequencer();
+    error SequencerAlreadyExists();
+    error SequencerDoesNotExist();
+    error Unauthorized();
+
+    function insertSequencer(address sequencer) external;
+
+    function removeSequencer(address sequencer) external;
+
+    function getCurrentSequencer(uint256 nonce) external view returns (address);
+}

--- a/test/EspressoRollupSequencerManager.t.sol
+++ b/test/EspressoRollupSequencerManager.t.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import {EspressoRollupSequencerManager} from "../src/EspressoRollupSequencerManager.sol";
+import {IEspressoRollupSequencerManager} from "../src/interface/IEspressoRollupSequencerManager.sol";
+
+contract EspressoRollupSequencerManagerTest is Test {
+    EspressoRollupSequencerManager public rollupSequencerManager;
+    address[] public initialSequencers;
+
+    function setUp() public {
+        rollupSequencerManager = new EspressoRollupSequencerManager(
+            initialSequencers
+        );
+    }
+    function testInsertSequencer() public {
+        address sequencer = address(0x123);
+        vm.expectEmit(true, true, true, true);
+        emit IEspressoRollupSequencerManager.SequencerAdded(sequencer);
+        rollupSequencerManager.insertSequencer(sequencer);
+        assertEq(rollupSequencerManager.currentSequencerCount(), 1);
+        assertEq(rollupSequencerManager.sequencerToNonce(sequencer), 1);
+        assertEq(rollupSequencerManager.nonceToSequencer(1), sequencer);
+        assertEq(rollupSequencerManager.globalNonce(), 2);
+    }
+
+    function testInsertSequencerFailsIfSequencerAlreadyExists() public {
+        address sequencer = address(0x123);
+        rollupSequencerManager.insertSequencer(sequencer);
+        vm.expectRevert(
+            IEspressoRollupSequencerManager.SequencerAlreadyExists.selector
+        );
+        rollupSequencerManager.insertSequencer(sequencer);
+    }
+
+    function testInsertFailsIfNotAuthorized() public {
+        address sequencer = address(0x123);
+        vm.prank(address(0x126));
+        vm.expectRevert(IEspressoRollupSequencerManager.Unauthorized.selector);
+        rollupSequencerManager.insertSequencer(sequencer);
+    }
+
+    function testRemoveSequencer() public {
+        address sequencer = address(0x123);
+        rollupSequencerManager.insertSequencer(sequencer);
+        vm.expectEmit(true, true, true, true);
+        emit IEspressoRollupSequencerManager.SequencerRemoved(sequencer);
+        rollupSequencerManager.removeSequencer(sequencer);
+        assertEq(rollupSequencerManager.currentSequencerCount(), 0);
+        assertEq(rollupSequencerManager.sequencerToNonce(sequencer), 0);
+        assertEq(rollupSequencerManager.nonceToSequencer(1), address(0));
+        // Check global nonce should not change
+        assertEq(rollupSequencerManager.globalNonce(), 2);
+    }
+
+    function testRemoveSequencerFailsIfSequencerDoesNotExist() public {
+        address sequencer = address(0x123);
+        vm.expectRevert(
+            IEspressoRollupSequencerManager.SequencerDoesNotExist.selector
+        );
+        rollupSequencerManager.removeSequencer(sequencer);
+    }
+
+    function testRemoveSequencerFailsIfNotAuthorized() public {
+        address sequencer = address(0x123);
+        rollupSequencerManager.insertSequencer(sequencer);
+        vm.prank(address(0x126));
+        vm.expectRevert(IEspressoRollupSequencerManager.Unauthorized.selector);
+        rollupSequencerManager.removeSequencer(sequencer);
+    }
+
+    function testGetCurrentSequencer() public {
+        address sequencer1 = address(0x123);
+        address sequencer2 = address(0x456);
+        rollupSequencerManager.insertSequencer(sequencer1);
+        rollupSequencerManager.insertSequencer(sequencer2);
+        assertEq(rollupSequencerManager.getCurrentSequencer(1), sequencer2);
+        assertEq(rollupSequencerManager.getCurrentSequencer(2), sequencer1);
+    }
+
+    function testGetCurrentSequencerFailsIViewNumberGreaterThanSequencerLength()
+        public
+    {
+        address sequencer1 = address(0x123);
+        address sequencer2 = address(0x456);
+        rollupSequencerManager.insertSequencer(sequencer1);
+        rollupSequencerManager.insertSequencer(sequencer2);
+        assertEq(rollupSequencerManager.getCurrentSequencer(5), sequencer2);
+        // remove sequencer
+        rollupSequencerManager.removeSequencer(sequencer1);
+        assertEq(rollupSequencerManager.getCurrentSequencer(5), sequencer2);
+    }
+}

--- a/test/EspressoRollupSequencerManager.t.sol
+++ b/test/EspressoRollupSequencerManager.t.sol
@@ -10,10 +10,9 @@ contract EspressoRollupSequencerManagerTest is Test {
     address[] public initialSequencers;
 
     function setUp() public {
-        rollupSequencerManager = new EspressoRollupSequencerManager(
-            initialSequencers
-        );
+        rollupSequencerManager = new EspressoRollupSequencerManager(initialSequencers);
     }
+
     function testInsertSequencer() public {
         address sequencer = address(0x123);
         vm.expectEmit(true, true, true, true);
@@ -28,9 +27,7 @@ contract EspressoRollupSequencerManagerTest is Test {
     function testInsertSequencerFailsIfSequencerAlreadyExists() public {
         address sequencer = address(0x123);
         rollupSequencerManager.insertSequencer(sequencer);
-        vm.expectRevert(
-            IEspressoRollupSequencerManager.SequencerAlreadyExists.selector
-        );
+        vm.expectRevert(IEspressoRollupSequencerManager.SequencerAlreadyExists.selector);
         rollupSequencerManager.insertSequencer(sequencer);
     }
 
@@ -56,9 +53,7 @@ contract EspressoRollupSequencerManagerTest is Test {
 
     function testRemoveSequencerFailsIfSequencerDoesNotExist() public {
         address sequencer = address(0x123);
-        vm.expectRevert(
-            IEspressoRollupSequencerManager.SequencerDoesNotExist.selector
-        );
+        vm.expectRevert(IEspressoRollupSequencerManager.SequencerDoesNotExist.selector);
         rollupSequencerManager.removeSequencer(sequencer);
     }
 
@@ -79,9 +74,7 @@ contract EspressoRollupSequencerManagerTest is Test {
         assertEq(rollupSequencerManager.getCurrentSequencer(2), sequencer1);
     }
 
-    function testGetCurrentSequencerFailsIViewNumberGreaterThanSequencerLength()
-        public
-    {
+    function testGetCurrentSequencerFailsIViewNumberGreaterThanSequencerLength() public {
         address sequencer1 = address(0x123);
         address sequencer2 = address(0x456);
         rollupSequencerManager.insertSequencer(sequencer1);

--- a/test/EspressoRollupSequencerManager.t.sol
+++ b/test/EspressoRollupSequencerManager.t.sol
@@ -16,7 +16,7 @@ contract EspressoRollupSequencerManagerTest is Test {
     function testInsertSequencer() public {
         address sequencer = address(0x123);
         vm.expectEmit(true, true, true, true);
-        emit IEspressoRollupSequencerManager.SequencerAdded(sequencer);
+        emit IEspressoRollupSequencerManager.SequencerAdded(sequencer, 1);
         rollupSequencerManager.insertSequencer(sequencer);
         assertEq(rollupSequencerManager.currentSequencerCount(), 1);
         assertEq(rollupSequencerManager.sequencerToNonce(sequencer), 1);
@@ -42,7 +42,7 @@ contract EspressoRollupSequencerManagerTest is Test {
         address sequencer = address(0x123);
         rollupSequencerManager.insertSequencer(sequencer);
         vm.expectEmit(true, true, true, true);
-        emit IEspressoRollupSequencerManager.SequencerRemoved(sequencer);
+        emit IEspressoRollupSequencerManager.SequencerRemoved(sequencer, 1);
         rollupSequencerManager.removeSequencer(sequencer);
         assertEq(rollupSequencerManager.currentSequencerCount(), 0);
         assertEq(rollupSequencerManager.sequencerToNonce(sequencer), 0);


### PR DESCRIPTION
 # Description
RollupSequencerManager is designed to manage a list of multiple sequencers in a round robin fashion. 
It uses a red-black tree to manage the list of the sequencers.

# Design
Important considerations in this design is that there is a `globalNonce` which increases overtime with addition of new addresses ( note: its representing time and as a reason it should not decrease). Because `red-black` tree stores the entries in ascending order each address will be stored based on its `globalNonce`. 

Along with this, we also maintain a mapping from globalNonce to addresses and vice-versa for convenience. 

# Tests

Run `forge test` to run all the tests 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210264179885236