### PR TITLE
Update interfaces to EspressoTEEVerifier contracts to support TEE caff node.

### DIFF
--- a/src/interface/IEspressoNitroTEEVerifier.sol
+++ b/src/interface/IEspressoNitroTEEVerifier.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
-import {Service} from "./IEspressoTEEVerifier.sol"
+
+import {Service} from "./IEspressoTEEVerifier.sol";
+
 interface IEspressoNitroTEEVerifier {
     // This error is thrown when the PCR0 values don't match
     error InvalidAWSEnclaveHash();
@@ -34,7 +36,7 @@ interface IEspressoNitroTEEVerifier {
     function verifyClientCert(bytes calldata certificate, bytes32 parentCertHash) external;
     function certVerified(bytes32 certHash) external view returns (bool);
 
-    function setEnclaveHash(bytes32 enclaveHash, bool valid, ) external;
+    function setEnclaveHash(bytes32 enclaveHash, bool valid) external;
     /*
     * @notice This function is responsible for removing registered addresses from the list of valid Caff Nodes
     */

--- a/src/interface/IEspressoNitroTEEVerifier.sol
+++ b/src/interface/IEspressoNitroTEEVerifier.sol
@@ -1,15 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {ServiceType} from "./IEspressoTEEVerifier.sol";
+import "./IEspressoTEEVerifier.sol";
 
 interface IEspressoNitroTEEVerifier {
     // This error is thrown when the PCR0 values don't match
     error InvalidAWSEnclaveHash();
 
-    event AWSEnclaveHashSet(bytes32 enclaveHash, bool valid, ServiceType service);
-    event AWSServiceRegistered(address signer, bytes32 enclaveHash, ServiceType service);
-    event DeletedAWSRegisteredService(address signer, ServiceType service);
+    event AWSEnclaveHashSet(
+        bytes32 enclaveHash, bool valid, IEspressoTEEVerifier.ServiceType service
+    );
+    event AWSServiceRegistered(
+        address signer, bytes32 enclaveHash, IEspressoTEEVerifier.ServiceType service
+    );
+    event DeletedAWSRegisteredService(address signer, IEspressoTEEVerifier.ServiceType service);
 
     /*
     * @notice This function is for checking the registration status of AWS Nitro TEE Caff Nodes and is a helper function for the EspressoTEEVerifier
@@ -36,7 +40,11 @@ interface IEspressoNitroTEEVerifier {
     function verifyClientCert(bytes calldata certificate, bytes32 parentCertHash) external;
     function certVerified(bytes32 certHash) external view returns (bool);
 
-    function setEnclaveHash(bytes32 enclaveHash, bool valid, ServiceType service) external;
+    function setEnclaveHash(
+        bytes32 enclaveHash,
+        bool valid,
+        IEspressoTEEVerifier.ServiceType service
+    ) external;
     /*
     * @notice This function is responsible for removing registered addresses from the list of valid Caff Nodes
     */

--- a/src/interface/IEspressoNitroTEEVerifier.sol
+++ b/src/interface/IEspressoNitroTEEVerifier.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {Service} from "./IEspressoTEEVerifier.sol";
+import {ServiceType} from "./IEspressoTEEVerifier.sol";
 
 interface IEspressoNitroTEEVerifier {
     // This error is thrown when the PCR0 values don't match
     error InvalidAWSEnclaveHash();
 
-    event AWSEnclaveHashSet(bytes32 enclaveHash, bool valid, Service service);
-    event AWSServiceRegistered(address signer, bytes32 enclaveHash, Service service);
-    event DeletedAWSRegisteredService(address signer, Service service);
+    event AWSEnclaveHashSet(bytes32 enclaveHash, bool valid, ServiceType service);
+    event AWSServiceRegistered(address signer, bytes32 enclaveHash, ServiceType service);
+    event DeletedAWSRegisteredService(address signer, ServiceType service);
 
     /*
     * @notice This function is for checking the registration status of AWS Nitro TEE Caff Nodes and is a helper function for the EspressoTEEVerifier
@@ -36,7 +36,7 @@ interface IEspressoNitroTEEVerifier {
     function verifyClientCert(bytes calldata certificate, bytes32 parentCertHash) external;
     function certVerified(bytes32 certHash) external view returns (bool);
 
-    function setEnclaveHash(bytes32 enclaveHash, bool valid) external;
+    function setEnclaveHash(bytes32 enclaveHash, bool valid, ServiceType service) external;
     /*
     * @notice This function is responsible for removing registered addresses from the list of valid Caff Nodes
     */

--- a/src/interface/IEspressoNitroTEEVerifier.sol
+++ b/src/interface/IEspressoNitroTEEVerifier.sol
@@ -9,9 +9,14 @@ interface IEspressoNitroTEEVerifier {
     event AWSServiceRegistered(address signer, bytes32 enclaveHash, Service service);
     event DeletedAWSRegisteredService(address signer, Service service);
 
-    //This will serve to check if a Caff node is regsitered in the NitroTEEVerifier contract.
+    /*
+    * @notice This function is for checking the registration status of AWS Nitro TEE Caff Nodes and is a helper function for the EspressoTEEVerifier
+    */
     function registeredCaffNode(address signer) external view returns (bool);
 
+    /*
+    * @notice This function is for checking the registration status of AWS Nitro TEE Batch Posters and is a helper function for the EspressoTEEVerifier
+    */
     function registeredBatchPoster(address signer) external view returns (bool);
     function registeredEnclaveHash(bytes32 enclaveHash) external view returns (bool);
 

--- a/src/interface/IEspressoNitroTEEVerifier.sol
+++ b/src/interface/IEspressoNitroTEEVerifier.sol
@@ -1,23 +1,41 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
-
+import {Service} from "./IEspressoTEEVerifier.sol"
 interface IEspressoNitroTEEVerifier {
     // This error is thrown when the PCR0 values don't match
     error InvalidAWSEnclaveHash();
 
-    event AWSEnclaveHashSet(bytes32 enclaveHash, bool valid);
-    event AWSSignerRegistered(address signer, bytes32 enclaveHash);
-    event DeletedAWSRegisteredSigner(address signer);
+    event AWSEnclaveHashSet(bytes32 enclaveHash, bool valid, Service service);
+    event AWSServiceRegistered(address signer, bytes32 enclaveHash, Service service);
+    event DeletedAWSRegisteredService(address signer, Service service);
 
-    function registeredSigners(address signer) external view returns (bool);
+    //This will serve to check if a Caff node is regsitered in the NitroTEEVerifier contract.
+    function registeredCaffNode(address signer) external view returns (bool);
+
+    function registeredBatchPoster(address signer) external view returns (bool);
     function registeredEnclaveHash(bytes32 enclaveHash) external view returns (bool);
 
-    function registerSigner(bytes calldata attestation, bytes calldata data) external;
+    /*
+    * @notice This function is for registering AWS Nitro TEE Caff Nodes and is a helper function for the EspressoTEEVerifier
+    */
+    function registerCaffNode(bytes calldata attestation, bytes calldata data) external;
+
+    /*
+    * @notice This function is for registering AWS Nitro Batch Posters and is a helper function for the EspressoTEEVerifier
+    */
+    function registerBatchPoster(bytes calldata verificationData, bytes calldata data) external;
 
     function verifyCACert(bytes calldata certificate, bytes32 parentCertHash) external;
     function verifyClientCert(bytes calldata certificate, bytes32 parentCertHash) external;
     function certVerified(bytes32 certHash) external view returns (bool);
 
-    function setEnclaveHash(bytes32 enclaveHash, bool valid) external;
-    function deleteRegisteredSigners(address[] memory signers) external;
+    function setEnclaveHash(bytes32 enclaveHash, bool valid, ) external;
+    /*
+    * @notice This function is responsible for removing registered addresses from the list of valid Caff Nodes
+    */
+    function deleteRegisteredCaffNodes(address[] memory signers) external;
+    /*
+    * @notice This function is responsible for removing registered addresses from the list of valid Batch Posters
+    */
+    function deleteRegisteredBatchPosters(address[] memory signers) external;
 }

--- a/src/interface/IEspressoSGXTEEVerifier.sol
+++ b/src/interface/IEspressoSGXTEEVerifier.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import {Header} from "@automata-network/dcap-attestation/contracts/types/CommonStruct.sol";
 import {EnclaveReport} from "@automata-network/dcap-attestation/contracts/types/V3Structs.sol";
-import {Service} from "./IEspressoTEEVerifier.sol";
+import {ServiceType} from "./IEspressoTEEVerifier.sol";
 
 interface IEspressoSGXTEEVerifier {
     // We only support version 3 for now
@@ -13,7 +13,7 @@ interface IEspressoSGXTEEVerifier {
     // This error is thrown when the enclave report fails to parse
     error FailedToParseEnclaveReport();
     // This error is thrown when the mrEnclave don't match
-    error InvalidEnclaveHash(Service);
+    error InvalidEnclaveHash(ServiceType);
     // This error is thrown when the reportDataHash doesn't match the hash signed by the TEE
     error InvalidReportDataHash();
     // This error is thrown when the reportData is too short
@@ -25,9 +25,9 @@ interface IEspressoSGXTEEVerifier {
     // This error is thrown when the quote verifier address is invalid
     error InvalidQuoteVerifierAddress();
 
-    event EnclaveHashSet(bytes32 enclaveHash, bool valid, Service service);
-    event ServiceRegistered(address signer, bytes32 enclaveHash, Service service);
-    event DeletedRegisteredService(address signer, Service service);
+    event EnclaveHashSet(bytes32 enclaveHash, bool valid, ServiceType service);
+    event ServiceRegistered(address signer, bytes32 enclaveHash, ServiceType service);
+    event DeletedRegisteredService(address signer, ServiceType service);
 
     /*
     * @notice This function is for checking the registration status of Intel SGX TEE Batch Posters and is a helper function for the EspressoTEEVerifier
@@ -67,7 +67,7 @@ interface IEspressoSGXTEEVerifier {
     /*
     * @notice: This function is responsible for setting the validity of enclave hashes in this inner TEEVerifier contract, It will be 
     */
-    function setEnclaveHash(bytes32 enclaveHash, bool valid, Service serviceType) external;
+    function setEnclaveHash(bytes32 enclaveHash, bool valid, ServiceType serviceType) external;
     /*
     * @notice This function is responsible for removing registered addresses from the list of valid Caff Nodes
     */

--- a/src/interface/IEspressoSGXTEEVerifier.sol
+++ b/src/interface/IEspressoSGXTEEVerifier.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import {Header} from "@automata-network/dcap-attestation/contracts/types/CommonStruct.sol";
 import {EnclaveReport} from "@automata-network/dcap-attestation/contracts/types/V3Structs.sol";
+import {Service} from "./IEspressoTEEVerifier.sol";
 
 interface IEspressoSGXTEEVerifier {
     // We only support version 3 for now
@@ -12,7 +13,7 @@ interface IEspressoSGXTEEVerifier {
     // This error is thrown when the enclave report fails to parse
     error FailedToParseEnclaveReport();
     // This error is thrown when the mrEnclave don't match
-    error InvalidEnclaveHash();
+    error InvalidEnclaveHash(Service);
     // This error is thrown when the reportDataHash doesn't match the hash signed by the TEE
     error InvalidReportDataHash();
     // This error is thrown when the reportData is too short
@@ -24,14 +25,30 @@ interface IEspressoSGXTEEVerifier {
     // This error is thrown when the quote verifier address is invalid
     error InvalidQuoteVerifierAddress();
 
-    event EnclaveHashSet(bytes32 enclaveHash, bool valid);
-    event SignerRegistered(address signer, bytes32 enclaveHash);
-    event DeletedRegisteredSigner(address signer);
+    event EnclaveHashSet(bytes32 enclaveHash, bool valid, Service service);
+    event ServiceRegistered(address signer, bytes32 enclaveHash, Service service);
+    event DeletedRegisteredService(address signer, Service service);
 
-    function registeredSigners(address signer) external view returns (bool);
+    /*
+    * @notice This function is for checking the registration status of  Intel SGX TEE BatchPosters and is a helper function for the EspressoTEEVerifier
+    */
+    function registeredBatchPoster(address signer) external view returns (bool);
+
+    /*
+    * @notice This function is for checking the registration status of Intel SGX TEE Caff Nodes and is a helper function for the EspressoTEEVerifier
+    */
+    function registeredCaffNode(address signer) external view returns (bool);
+
     function registeredEnclaveHash(bytes32 enclaveHash) external view returns (bool);
 
-    function registerSigner(bytes calldata attestation, bytes calldata data) external;
+    /*
+    * @notice This function is for registering Intel SGX TEE Batch Posters and is a helper function for the EspressoTEEVerifier
+    */
+    function registerBatchPoster(bytes calldata attestation, bytes calldata data) external;
+    /*
+    * @notice This function is for checking the registration status of Intel SGX TEE BatchPosters and is a helper function for the EspressoTEEVerifier
+    */
+    function registerCaffNode(bytes calldata attestation, bytes calldata data) external;
 
     function verify(bytes calldata rawQuote, bytes32 reportDataHash)
         external
@@ -47,7 +64,16 @@ interface IEspressoSGXTEEVerifier {
         external
         pure
         returns (bool success, EnclaveReport memory enclaveReport);
-
-    function setEnclaveHash(bytes32 enclaveHash, bool valid) external;
-    function deleteRegisteredSigners(address[] memory signers) external;
+    /*
+    * @notice: This function is responsible for setting the validity of enclave hashes in this inner TEEVerifier contract, It will be 
+    */
+    function setEnclaveHash(bytes32 enclaveHash, bool valid, Service serviceType) external;
+    /*
+    * @notice This function is responsible for removing registered addresses from the list of valid Caff Nodes
+    */
+    function deleteRegisteredCaffNodes(address[] memory signers) external;
+    /*
+    * @notice This function is responsible for removing registered addresses from the list of valid Batch Posters
+    */
+    function deleteRegisteredBatchPosters(address[] memory signers) external;
 }

--- a/src/interface/IEspressoSGXTEEVerifier.sol
+++ b/src/interface/IEspressoSGXTEEVerifier.sol
@@ -30,7 +30,7 @@ interface IEspressoSGXTEEVerifier {
     event DeletedRegisteredService(address signer, Service service);
 
     /*
-    * @notice This function is for checking the registration status of  Intel SGX TEE BatchPosters and is a helper function for the EspressoTEEVerifier
+    * @notice This function is for checking the registration status of Intel SGX TEE Batch Posters and is a helper function for the EspressoTEEVerifier
     */
     function registeredBatchPoster(address signer) external view returns (bool);
 
@@ -46,7 +46,7 @@ interface IEspressoSGXTEEVerifier {
     */
     function registerBatchPoster(bytes calldata attestation, bytes calldata data) external;
     /*
-    * @notice This function is for checking the registration status of Intel SGX TEE BatchPosters and is a helper function for the EspressoTEEVerifier
+    * @notice This function is for registering Intel SGX TEE Batch Posters and is a helper function for the EspressoTEEVerifier
     */
     function registerCaffNode(bytes calldata attestation, bytes calldata data) external;
 

--- a/src/interface/IEspressoSGXTEEVerifier.sol
+++ b/src/interface/IEspressoSGXTEEVerifier.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import {Header} from "@automata-network/dcap-attestation/contracts/types/CommonStruct.sol";
 import {EnclaveReport} from "@automata-network/dcap-attestation/contracts/types/V3Structs.sol";
-import {ServiceType} from "./IEspressoTEEVerifier.sol";
+import "./IEspressoTEEVerifier.sol";
 
 interface IEspressoSGXTEEVerifier {
     // We only support version 3 for now
@@ -13,7 +13,7 @@ interface IEspressoSGXTEEVerifier {
     // This error is thrown when the enclave report fails to parse
     error FailedToParseEnclaveReport();
     // This error is thrown when the mrEnclave don't match
-    error InvalidEnclaveHash(ServiceType);
+    error InvalidEnclaveHash();
     // This error is thrown when the reportDataHash doesn't match the hash signed by the TEE
     error InvalidReportDataHash();
     // This error is thrown when the reportData is too short
@@ -25,9 +25,11 @@ interface IEspressoSGXTEEVerifier {
     // This error is thrown when the quote verifier address is invalid
     error InvalidQuoteVerifierAddress();
 
-    event EnclaveHashSet(bytes32 enclaveHash, bool valid, ServiceType service);
-    event ServiceRegistered(address signer, bytes32 enclaveHash, ServiceType service);
-    event DeletedRegisteredService(address signer, ServiceType service);
+    event EnclaveHashSet(bytes32 enclaveHash, bool valid, IEspressoTEEVerifier.ServiceType service);
+    event ServiceRegistered(
+        address signer, bytes32 enclaveHash, IEspressoTEEVerifier.ServiceType service
+    );
+    event DeletedRegisteredService(address signer, IEspressoTEEVerifier.ServiceType service);
 
     /*
     * @notice This function is for checking the registration status of Intel SGX TEE Batch Posters and is a helper function for the EspressoTEEVerifier
@@ -67,7 +69,11 @@ interface IEspressoSGXTEEVerifier {
     /*
     * @notice: This function is responsible for setting the validity of enclave hashes in this inner TEEVerifier contract, It will be 
     */
-    function setEnclaveHash(bytes32 enclaveHash, bool valid, ServiceType serviceType) external;
+    function setEnclaveHash(
+        bytes32 enclaveHash,
+        bool valid,
+        IEspressoTEEVerifier.ServiceType serviceType
+    ) external;
     /*
     * @notice This function is responsible for removing registered addresses from the list of valid Caff Nodes
     */

--- a/src/interface/IEspressoTEEVerifier.sol
+++ b/src/interface/IEspressoTEEVerifier.sol
@@ -13,9 +13,9 @@ interface IEspressoTEEVerifier {
         NITRO
     }
     /**
-    * @notice Enum for representing services that can be registered via the EspressoTEEVerifier contract
-    */
-    enum ServiceType{
+     * @notice Enum for representing services that can be registered via the EspressoTEEVerifier contract
+     */
+    enum ServiceType {
         BatchPoster,
         CaffNode
     }
@@ -24,7 +24,7 @@ interface IEspressoTEEVerifier {
     error InvalidSignature();
     // This error is thrown when the TEE type is not supported
     error UnsupportedTeeType();
-    // This error is thrown when the ServiceType enum provided to a method is unsupported for that method. 
+    // This error is thrown when the ServiceType enum provided to a method is unsupported for that method.
     error UnsupportedServiceType();
 
     // Get address of Nitro TEE Verifier
@@ -41,11 +41,18 @@ interface IEspressoTEEVerifier {
 
     // Function to register a service which has been attested by a TEE or Attestation Verifier
     // This function can has succeeded if it does not revert.
-    function registerService(bytes calldata verificationData, bytes calldata data, TeeType teeType, ServiceType serviceType)
-        external;
+    function registerService(
+        bytes calldata verificationData,
+        bytes calldata data,
+        TeeType teeType,
+        ServiceType serviceType
+    ) external;
 
     // Function to retrieve whether a service is registered or not
-    function registeredService(address signer, TeeType teeType, ServiceType serviceType) external view returns (bool);
+    function registeredService(address signer, TeeType teeType, ServiceType serviceType)
+        external
+        view
+        returns (bool);
 
     function registeredEnclaveHashes(bytes32 enclaveHash, TeeType teeType, ServiceType serviceType)
         external

--- a/src/interface/IEspressoTEEVerifier.sol
+++ b/src/interface/IEspressoTEEVerifier.sol
@@ -12,11 +12,20 @@ interface IEspressoTEEVerifier {
         SGX,
         NITRO
     }
+    /**
+    * @notice Enum for representing services that can be registered via the EspressoTEEVerifier contract
+    */
+    enum ServiceType{
+        BatchPoster,
+        CaffNode
+    }
     // This error is thrown when the signature is invalid
 
     error InvalidSignature();
     // This error is thrown when the TEE type is not supported
     error UnsupportedTeeType();
+    // This error is thrown when the ServiceType enum provided to a method is unsupported for that method. 
+    error UnsupportedServiceType();
 
     // Get address of Nitro TEE Verifier
     function espressoNitroTEEVerifier() external view returns (IEspressoNitroTEEVerifier);
@@ -30,14 +39,15 @@ interface IEspressoTEEVerifier {
         view
         returns (bool);
 
-    // Function to register a signer which has been attested by the TEE
-    function registerSigner(bytes calldata attestation, bytes calldata data, TeeType teeType)
+    // Function to register a service which has been attested by a TEE or Attestation Verifier
+    // This function can has succeeded if it does not revert.
+    function registerService(bytes calldata verificationData, bytes calldata data, TeeType teeType, ServiceType serviceType)
         external;
 
-    // Function to retrieve whether a signer is registered or not
-    function registeredSigners(address signer, TeeType teeType) external view returns (bool);
+    // Function to retrieve whether a service is registered or not
+    function registeredService(address signer, TeeType teeType, ServiceType serviceType) external view returns (bool);
 
-    function registeredEnclaveHashes(bytes32 enclaveHash, TeeType teeType)
+    function registeredEnclaveHashes(bytes32 enclaveHash, TeeType teeType, ServiceType serviceType)
         external
         view
         returns (bool);


### PR DESCRIPTION
Closes Asana Ticket: [Create new Interface](https://app.asana.com/1/1208976916964769/project/1210454276750014/task/1211302615128407?focus=true) 

### This PR:
Updates the interfaces for the EspressoTEEVerifier contracts to support registering the TEE Caff node in addition to batch posters.

### This PR does not:
Implement the contract behavior necessary to produce these functions.
Currently, this PR does not fix any of the compilation issues that would arise from changing the interfaces, but not the contracts themselves.

### Key places to review:
`src/interface/IEspresso*.sol
