### PR TITLE
point to automata release v0.1.2

### DIFF
--- a/scripts/deploy-nitro-enclave-verifier.sh
+++ b/scripts/deploy-nitro-enclave-verifier.sh
@@ -64,7 +64,7 @@ echo ""
 echo "=== Step 2: Deploying SP1Verifier (chain ${CHAIN_ID}) ==="
 
 SP1_OUTPUT=$(forge create \
-    lib/sp1-contracts/contracts/src/v5.0.0/SP1VerifierGroth16.sol:SP1Verifier \
+    lib/sp1-contracts/contracts/src/v6.1.0/SP1VerifierGroth16.sol:SP1Verifier \
     --rpc-url "$RPC_URL" \
     --private-key "$PRIVATE_KEY" \
     --broadcast \


### PR DESCRIPTION
## This PR

- Bumps the `aws-nitro-enclave-attestation` submodule from v0.1.1 to v0.1.2, which pins the nested `sp1-contracts` submodule to a commit containing the SP1 v6.1 verifier source.
- Updates the deploy script to deploy `SP1VerifierGroth16` from `v6.1.0/` instead of `v5.0.0/`, matching the v6.1 ELF and program IDs already shipped in v0.1.1+.

## Key Places to Review

- `scripts/deploy-nitro-enclave-verifier.sh` — single path change from `v5.0.0` → `v6.1.0` SP1VerifierGroth16 source.
- `lib/aws-nitro-enclave-attestation` — submodule pointer bump to upstream tag `v0.1.2` (`65c4a42`); fresh clones need `git submodule update --init --recursive` to pull the nested v6 sp1-contracts.

## How to Test This PR

1. Initialize submodules and run the deploy against Sepolia:

 ```bash
 git submodule update --init --recursive                                                                                                      
 ./scripts/deploy-nitro-enclave-verifier.sh --force
 ```

2. Confirm the deployed SP1Verifier reports the v6 selector by reading `VERIFIER_HASH()` and `setZkConfiguration` succeeds with the v6 program IDs from `lib/aws-nitro-enclave-attestation/samples/sp1_program_id.json`.